### PR TITLE
Use FromForm for API params in POST requests

### DIFF
--- a/Registry.Web/Controllers/UsersController.cs
+++ b/Registry.Web/Controllers/UsersController.cs
@@ -24,7 +24,7 @@ namespace Registry.Web.Controllers
 
         [AllowAnonymous]
         [HttpPost("authenticate")]
-        public IActionResult Authenticate([FromBody]AuthenticateRequest model)
+        public IActionResult Authenticate([FromForm]AuthenticateRequest model)
         {
             var response = _userService.Authenticate(model);
 


### PR DESCRIPTION
Closes #5 

Form data makes more sense (imo) for sending POST parameters. It can be more easily incorporated into web forms and does not require one to write JSON when querying from command line or using libraries.

Eg. `curl -X POST http://localhost:5000/users/authenticate -d username=admin -d password=password`

Vs:

`curl X POST http://localhost:5000/users/authenticate --data '{"username": "admin", "password", "password"}' --header "Content-Type: application/json"`

