### PR TITLE
Added dockerfile for Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:20.04
+MAINTAINER Piero Toffanin <pt@uav4geo.com>
+ENV DEBIAN_FRONTEND noninteractive
+
+#install dependencies
+RUN apt update && apt install  -y --fix-missing --no-install-recommends\
+    build-essential \
+    ca-certificates \
+    apt-transport-https \
+    cmake \
+    git \
+    sqlite3 \
+    spatialite-bin \
+    exiv2 \
+    libexiv2-dev \
+    libgeos-dev \
+    libgdal-dev \
+    wget
+
+# Install dotnet
+
+RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb && \
+    dpkg -i /tmp/packages-microsoft-prod.deb && \
+    apt update && \
+    apt install -y dotnet-sdk-3.1
+
+RUN git clone --recurse-submodules https://github.com/DroneDB/DroneDB /ddb && \
+    cd /ddb && \
+    mkdir build && \
+    cd build && \
+    cmake .. && make -j$(nproc) && make install
+
+COPY . /registry
+
+# TODO: @Hedo88TH appsettings.json should be in the bin directory?
+# I shouldn't have to modify /registry/Registry.Web/appsettings.json
+# let's improve this.
+
+RUN rm /registry/Registry.Web/appsettings.json && ln -s /registry/docker/appsettings.json /registry/Registry.Web/appsettings.json
+WORKDIR /registry
+
+RUN apt clean && rm -r /tmp/*
+
+ENTRYPOINT ["/usr/bin/dotnet", "run", "--project", "Registry.Web"]

--- a/README.md
+++ b/README.md
@@ -10,13 +10,24 @@ To learn more check the wiki article: [REST Interface Specification](https://git
 
 ![dronedb-registry-architecture](https://user-images.githubusercontent.com/7868983/87065148-f4c46b80-c210-11ea-9f68-3e2dd13687bf.jpg)
 
-## Building
+## Running
+
+You can use docker to setup Registry:
+
+```
+git clone https://github.com/DroneDB/Registry
+cd Registry
+docker build . -t dronedb/registry
+docker run -ti -p 5000:5000 -p 5001:5001 dronedb/registry
+```
+
+## Building Natively
 
 ```
 dotnet build
 ```
 
-## Running
+## Running Natively
 
 ```
 dotnet run --project Registry.Web


### PR DESCRIPTION
This PR adds a Dockerfile.

Adds the `libddb.so` library (and dependencies) as well as the `ddb` binary.

We shouldn't use nuget to provide the library files on Linux (too complex). People deploying registry can use the dockerfile or build from source on Linux.

Windows should take advantage of nuget binaries however.

To build:

```
git clone https://github.com/DroneDB/Registry
cd Registry
docker build . -t dronedb/registry
docker run -ti -p 5000:5000 -p 5001:5001 dronedb/registry
```