### PR TITLE
Modified Share Init behaviour to rollback with subsequent calls

### DIFF
--- a/Registry.Adapters.DroneDB/Ddb.cs
+++ b/Registry.Adapters.DroneDB/Ddb.cs
@@ -16,6 +16,7 @@ namespace Registry.Adapters.DroneDB
 
         // TODO: Maybe all this "stuff" can be put in the config
         private const string InfoCommand = "info";
+        private const string RemoveCommand = "remove";
         private const string InitCommand = "init";
         private const int MaxWaitTime = 5000;
 
@@ -24,7 +25,7 @@ namespace Registry.Adapters.DroneDB
             _ddbExePath = ddbExePath;
         }
 
-       
+
         public IEnumerable<DdbInfo> Info(string path)
         {
 
@@ -38,13 +39,21 @@ namespace Registry.Adapters.DroneDB
             return lst;
         }
 
+        public void Remove(string ddbPath, string path)
+        {
+
+            var res = RunCommand($"{RemoveCommand} -d \"{ddbPath}\" -p \"{path}\"");
+            
+            return;
+        }
+
         public void CreateDatabase(string path)
         {
-            
+
             Directory.CreateDirectory(path);
 
             var res = RunCommand($"{InitCommand} -d \"{Path.GetFullPath(path)}\"");
-            
+
         }
 
         private string RunCommand(string parameters)
@@ -60,8 +69,12 @@ namespace Registry.Adapters.DroneDB
                 }
             };
 
-            p.StartInfo.EnvironmentVariables.Add("PROJ_LIB", Path.GetDirectoryName(Path.GetFullPath(_ddbExePath)));
+            if (!p.StartInfo.EnvironmentVariables.ContainsKey("PROJ_LIB"))
+            {
+                p.StartInfo.EnvironmentVariables.Add("PROJ_LIB", Path.GetDirectoryName(Path.GetFullPath(_ddbExePath)));
+            }
 
+            Debug.WriteLine($"PROJ_LIB = '{p.StartInfo.EnvironmentVariables["PROJ_LIB"]}'");
             Debug.WriteLine("Running command:");
             Debug.WriteLine($"{_ddbExePath} {parameters}");
 

--- a/Registry.Adapters.DroneDB/DdbStorage.cs
+++ b/Registry.Adapters.DroneDB/DdbStorage.cs
@@ -177,6 +177,7 @@ namespace Registry.Adapters.DroneDB
 
         public void Remove(string path)
         {
+            //_ddb.Remove(_dbPath, path);
             var entry = Entries.FirstOrDefault(item => item.Path == path);
 
             if (entry == null)

--- a/Registry.Ports/DroneDB/IDdb.cs
+++ b/Registry.Ports/DroneDB/IDdb.cs
@@ -9,5 +9,6 @@ namespace Registry.Ports.DroneDB
     {
         IEnumerable<DdbInfo> Info(string path);
         void CreateDatabase(string path);
+        void Remove(string ddbPath, string path);
     }
 }

--- a/Registry.Web.Data/Models/Batch.cs
+++ b/Registry.Web.Data/Models/Batch.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Data;
 using System.Text;
-using Registry.Common;
 
 namespace Registry.Web.Data.Models
 {
@@ -32,24 +31,4 @@ namespace Registry.Web.Data.Models
     {
         Running, Committed, Rolledback
     }
-
-
-    public class Entry
-    {
-        [Key]
-        public string Path { get; set; }
-        
-        [Required]
-        public string Hash { get; set; }
-        [Required]
-        public EntryType Type { get; set; }
-        [Required]
-        public int Size { get; set; }
-        [Required]
-        public DateTime AddedOn { get; set; }
-
-        [Required]
-        public Batch Batch { get; set; }
-    }
-
 }

--- a/Registry.Web.Data/Models/Batch.cs
+++ b/Registry.Web.Data/Models/Batch.cs
@@ -22,9 +22,17 @@ namespace Registry.Web.Data.Models
         public DateTime Start { get; set; }
         public DateTime? End { get; set; }
 
+        public BatchStatus Status { get; set; }
+        
         public virtual ICollection<Entry> Entries { get; set; }
         
     }
+
+    public enum BatchStatus
+    {
+        Running, Committed, Rolledback
+    }
+
 
     public class Entry
     {

--- a/Registry.Web.Data/Models/Entry.cs
+++ b/Registry.Web.Data/Models/Entry.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using Registry.Common;
+
+namespace Registry.Web.Data.Models
+{
+    public class Entry
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Required]
+        public string Path { get; set; }
+        
+        [Required]
+        public string Hash { get; set; }
+        [Required]
+        public EntryType Type { get; set; }
+        [Required]
+        public int Size { get; set; }
+        [Required]
+        public DateTime AddedOn { get; set; }
+
+        [Required]
+        public Batch Batch { get; set; }
+    }
+}

--- a/Registry.Web.Data/RegistryContext.cs
+++ b/Registry.Web.Data/RegistryContext.cs
@@ -32,5 +32,6 @@ namespace Registry.Web.Data
 
         public DbSet<Batch> Batches { get; set; }
         public DbSet<Entry> Entries { get; set; }
+
     }
 }

--- a/Registry.Web.Test/ObjectManagerTest.cs
+++ b/Registry.Web.Test/ObjectManagerTest.cs
@@ -199,8 +199,8 @@ namespace Registry.Web.Test
                 fileName);
 
             res.Should().HaveCount(0);
-
-            var newFileUrl = "https://github.com/pierotofy/drone_dataset_brighton_beach/raw/master/" + fileName;
+            
+            var newFileUrl = "https://github.com/DroneDB/test_data/raw/master/test-datasets/drone_dataset_brighton_beach/" + fileName;
 
             var ret = await objectManager.AddNew(MagicStrings.PublicOrganizationSlug, MagicStrings.DefaultDatasetSlug,
                 fileName, CommonUtils.SmartDownloadData(newFileUrl));

--- a/Registry.Web.Test/ShareManagerTest.cs
+++ b/Registry.Web.Test/ShareManagerTest.cs
@@ -137,7 +137,7 @@ namespace Registry.Web.Test
             const string organizationTestSlug = "test";
             const string datasetTestSlug = "first";
             const string testPassword = "ciaoatutti";
-            const string newFileUrl = "https://github.com/pierotofy/drone_dataset_brighton_beach/raw/master/" + fileName;
+            const string newFileUrl = "https://github.com/DroneDB/test_data/raw/master/test-datasets/drone_dataset_brighton_beach/" + fileName;
 
             // ListBatches
             var batches = (await shareManager.ListBatches(MagicStrings.PublicOrganizationSlug, MagicStrings.DefaultDatasetSlug)).ToArray();
@@ -249,7 +249,7 @@ namespace Registry.Web.Test
             const string organizationTestSlug = "test";
             const string datasetTestSlug = "first";
             const string testPassword = "ciaoatutti";
-            const string newFileUrl = "https://github.com/pierotofy/drone_dataset_brighton_beach/raw/master/" + fileName;
+            const string newFileUrl = "https://github.com/DroneDB/test_data/raw/master/test-datasets/drone_dataset_brighton_beach/" + fileName;
 
             // ListBatches
             var batches = (await shareManager.ListBatches(MagicStrings.PublicOrganizationSlug, MagicStrings.DefaultDatasetSlug)).ToArray();

--- a/Registry.Web.Test/ShareManagerTest.cs
+++ b/Registry.Web.Test/ShareManagerTest.cs
@@ -98,8 +98,8 @@ namespace Registry.Web.Test
         [Explicit("Cannot run in CI")]
         public async Task EndToEnd_HappyPath()
         {
-
-            const string fileName = "DJI_0028.JPG";
+            /* INITIALIZATION & SETUP */
+            const string userName = "admin";
 
             using var test = new TestFS(Test1ArchiveUrl, BaseTestFolder, true);
             
@@ -109,10 +109,10 @@ namespace Registry.Web.Test
             _authManagerMock.Setup(o => o.IsUserAdmin()).Returns(Task.FromResult(true));
             _authManagerMock.Setup(o => o.GetCurrentUser()).Returns(Task.FromResult(new User
             {
-                UserName = "admin",
+                UserName = userName,
                 Email = "admin@example.com"
             }));
-            _authManagerMock.Setup(o => o.SafeGetCurrentUserName()).Returns(Task.FromResult("admin"));
+            _authManagerMock.Setup(o => o.SafeGetCurrentUserName()).Returns(Task.FromResult(userName));
             
             var sys = new PhysicalObjectSystem(Path.Combine(test.TestFolder, StorageFolder));
             sys.SyncBucket($"{MagicStrings.PublicOrganizationSlug}-{MagicStrings.DefaultDatasetSlug}");
@@ -127,15 +127,22 @@ namespace Registry.Web.Test
 
             var shareManager = new ShareManager(_shareManagerLogger, objectManager, datasetManager, organizationsManager, webUtils, _authManagerMock.Object, context);
 
-            var batches = (await shareManager.ListBatches(MagicStrings.PublicOrganizationSlug, MagicStrings.DefaultDatasetSlug)).ToArray();
+            /* TEST */
 
-            batches.Should().BeEmpty();
-
+            const string fileName = "DJI_0028.JPG";
+            const int fileSize = 3140384;
+            const string fileHash = "7cf58d0a06c56092aa5d6e108e385ad942225c75b462406cdf50d66f829572d3";
             const string organizationTestName = "test";
             const string datasetTestName = "First";
             const string organizationTestSlug = "test";
             const string datasetTestSlug = "first";
+            const string testPassword = "ciaoatutti";
+            const string newFileUrl = "https://github.com/pierotofy/drone_dataset_brighton_beach/raw/master/" + fileName;
 
+            // ListBatches
+            var batches = (await shareManager.ListBatches(MagicStrings.PublicOrganizationSlug, MagicStrings.DefaultDatasetSlug)).ToArray();
+            batches.Should().BeEmpty();
+            
             var res = await organizationsManager.AddNew(new OrganizationDto
             {
                 Name = organizationTestName,
@@ -143,9 +150,11 @@ namespace Registry.Web.Test
                 Slug = organizationTestSlug
             });
 
+            res.Description.Should().BeNull();
+            res.IsPublic.Should().BeTrue();
+            res.Slug.Should().Be(organizationTestSlug);
+            res.Name.Should().Be(organizationTestName);
             
-            const string testPassword = "ciaoatutti";
-
             // Initialize
             var token = await shareManager.Initialize(new ShareInitDto
             {
@@ -156,26 +165,191 @@ namespace Registry.Web.Test
 
             token.Should().NotBeNullOrWhiteSpace();
 
+            // ListBatches
             batches = (await shareManager.ListBatches(organizationTestSlug, datasetTestSlug)).ToArray();
 
             batches.Should().HaveCount(1);
 
-            var newFileUrl = "https://github.com/pierotofy/drone_dataset_brighton_beach/raw/master/" + fileName;
-
-            await shareManager.Upload(token, fileName, CommonUtils.SmartDownloadData(newFileUrl));
-
-            await shareManager.Commit(token);
-
-            batches = (await shareManager.ListBatches(organizationTestSlug, datasetTestSlug)).ToArray();
-
-            batches.Should().HaveCount(1);
             var batch = batches.First();
+
+            batch.UserName.Should().Be(userName);
+            batch.Status.Should().Be(BatchStatus.Running);
+            batch.End.Should().BeNull();
+
+            // Upload
+            var uploadRes = await shareManager.Upload(token, fileName, CommonUtils.SmartDownloadData(newFileUrl));
+
+            uploadRes.Path.Should().Be(fileName);
+            uploadRes.Size.Should().Be(fileSize);
+            uploadRes.Hash.Should().Be(fileHash);
+
+            // Commit
+            var commitRes = await shareManager.Commit(token);
+
+            commitRes.TotalSize.Should().Be(fileSize);
+            commitRes.ObjectsCount.Should().Be(1);
+            commitRes.Status.Should().Be(BatchStatus.Committed);
+
+            // ListBatches
+            batches = (await shareManager.ListBatches(organizationTestSlug, datasetTestSlug)).ToArray();
+
+            batches.Should().HaveCount(1);
+
+            batch = batches.First();
+
             batch.Token.Should().Be(token);
-            batch.UserName.Should().Be("admin");
-            batch.Entries.Should().HaveCount(1);
+            batch.UserName.Should().Be(userName);
             batch.End.Should().NotBeNull();
+            batch.Status.Should().Be(BatchStatus.Committed);
+            batch.Entries.Should().HaveCount(1);
 
         }
+
+        [Test]
+        [Explicit("Cannot run in CI")]
+        public async Task EndToEnd_ShareInit_After_ShareInit()
+        {
+
+            /* INITIALIZATION & SETUP */
+            const string userName = "admin";
+
+            using var test = new TestFS(Test1ArchiveUrl, BaseTestFolder, true);
+
+            await using var context = GetTest1Context();
+
+            _appSettingsMock.Setup(o => o.Value).Returns(_settings);
+            _authManagerMock.Setup(o => o.IsUserAdmin()).Returns(Task.FromResult(true));
+            _authManagerMock.Setup(o => o.GetCurrentUser()).Returns(Task.FromResult(new User
+            {
+                UserName = userName,
+                Email = "admin@example.com"
+            }));
+            _authManagerMock.Setup(o => o.SafeGetCurrentUserName()).Returns(Task.FromResult(userName));
+
+            var sys = new PhysicalObjectSystem(Path.Combine(test.TestFolder, StorageFolder));
+            sys.SyncBucket($"{MagicStrings.PublicOrganizationSlug}-{MagicStrings.DefaultDatasetSlug}");
+
+            var ddbFactory = new DdbFactory(_appSettingsMock.Object, _ddbFactoryLogger);
+            var webUtils = new WebUtils(_authManagerMock.Object, context);
+
+            var objectManager = new ObjectsManager(_objectManagerLogger, context, sys, _appSettingsMock.Object, ddbFactory, webUtils);
+
+            var datasetManager = new DatasetsManager(context, webUtils, _datasetsManagerLogger, objectManager, ddbFactory, _passwordHasher);
+            var organizationsManager = new OrganizationsManager(_authManagerMock.Object, context, webUtils, datasetManager, _organizationsManagerLogger);
+
+            var shareManager = new ShareManager(_shareManagerLogger, objectManager, datasetManager, organizationsManager, webUtils, _authManagerMock.Object, context);
+
+            /* TEST */
+
+            const string fileName = "DJI_0028.JPG";
+            const int fileSize = 3140384;
+            const string fileHash = "7cf58d0a06c56092aa5d6e108e385ad942225c75b462406cdf50d66f829572d3";
+            const string organizationTestName = "test";
+            const string datasetTestName = "First";
+            const string organizationTestSlug = "test";
+            const string datasetTestSlug = "first";
+            const string testPassword = "ciaoatutti";
+            const string newFileUrl = "https://github.com/pierotofy/drone_dataset_brighton_beach/raw/master/" + fileName;
+
+            // ListBatches
+            var batches = (await shareManager.ListBatches(MagicStrings.PublicOrganizationSlug, MagicStrings.DefaultDatasetSlug)).ToArray();
+            batches.Should().BeEmpty();
+
+            await organizationsManager.AddNew(new OrganizationDto
+            {
+                Name = organizationTestName,
+                IsPublic = true,
+                Slug = organizationTestSlug
+            });
+            
+            // Initialize
+            var token = await shareManager.Initialize(new ShareInitDto
+            {
+                Tag = $"{organizationTestSlug}/{datasetTestSlug}",
+                DatasetName = datasetTestName,
+                Password = testPassword
+            });
+
+            token.Should().NotBeNullOrWhiteSpace();
+
+            // ListBatches
+            batches = (await shareManager.ListBatches(organizationTestSlug, datasetTestSlug)).ToArray();
+
+            batches.Should().HaveCount(1);
+
+
+            // Upload
+            await shareManager.Upload(token, fileName, CommonUtils.SmartDownloadData(newFileUrl));
+
+            // Initialize
+            var newToken = await shareManager.Initialize(new ShareInitDto
+            {
+                Tag = $"{organizationTestSlug}/{datasetTestSlug}",
+                DatasetName = datasetTestName,
+                Password = testPassword
+            });
+
+            token.Should().NotBeNullOrWhiteSpace();
+
+            // ListBatches
+            batches = (await shareManager.ListBatches(organizationTestSlug, datasetTestSlug)).ToArray();
+
+            batches.Should().HaveCount(2);
+
+            var oldBatch = batches.FirstOrDefault(item => item.Token == token);
+            oldBatch.Should().NotBeNull();
+
+            // ReSharper disable once PossibleNullReferenceException
+            oldBatch.End.Should().NotBeNull();
+            oldBatch.Status.Should().Be(BatchStatus.Rolledback);
+
+            var newBatch = batches.FirstOrDefault(item => item.Token == newToken);
+            newBatch.Should().NotBeNull();
+
+            // ReSharper disable once PossibleNullReferenceException
+            newBatch.End.Should().BeNull();
+            newBatch.Status.Should().Be(BatchStatus.Running);
+
+            // Upload to old batch -> Exception
+            shareManager.Invoking(async x => await x.Upload(token, fileName, CommonUtils.SmartDownloadData(newFileUrl)))
+                .Should().Throw<BadRequestException>();
+
+            // Commit old batch -> Exception
+            shareManager.Invoking(async x => await shareManager.Commit(token))
+                .Should().Throw<BadRequestException>();
+
+            // Fix
+            context.Set<Entry>().Local.Clear();
+            
+            // Upload to new batch
+            var uploadRes = await shareManager.Upload(newToken, fileName, CommonUtils.SmartDownloadData(newFileUrl));
+            uploadRes.Path.Should().Be(fileName);
+            uploadRes.Size.Should().Be(fileSize);
+            uploadRes.Hash.Should().Be(fileHash);
+
+            // Commit
+            var commitRes = await shareManager.Commit(newToken);
+
+            commitRes.TotalSize.Should().Be(fileSize);
+            commitRes.ObjectsCount.Should().Be(1);
+            commitRes.Status.Should().Be(BatchStatus.Committed);
+
+            // ListBatches
+            batches = (await shareManager.ListBatches(organizationTestSlug, datasetTestSlug)).ToArray();
+
+            batches.Should().HaveCount(2);
+
+            //batches = (await shareManager.ListBatches(organizationTestSlug, datasetTestSlug)).ToArray();
+
+            //batches.Should().HaveCount(1);
+            //var batch = batches.First();
+            //batch.Token.Should().Be(token);
+            //batch.UserName.Should().Be("admin");
+            //batch.Entries.Should().HaveCount(1);
+            //batch.End.Should().NotBeNull();
+
+        }
+
 
 
 

--- a/Registry.Web/Extenders.cs
+++ b/Registry.Web/Extenders.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Registry.Ports.DroneDB;
 using Registry.Ports.DroneDB.Models;
 using Registry.Web.Data.Models;
@@ -172,6 +173,6 @@ namespace Registry.Web
             return new TagDto(org, ds);
 
         }
-
+        
     }
 }

--- a/Registry.Web/Models/DTO/BatchDto.cs
+++ b/Registry.Web/Models/DTO/BatchDto.cs
@@ -14,6 +14,7 @@ namespace Registry.Web.Models.DTO
         public DateTime Start { get; set; }
         public DateTime? End { get; set; }
 
+        public BatchStatus Status { get; set; }
         public IEnumerable<EntryDto> Entries { get; set; }
     }
 

--- a/Registry.Web/Models/DTO/UploadResultDto.cs
+++ b/Registry.Web/Models/DTO/UploadResultDto.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Registry.Web.Data.Models;
 
 namespace Registry.Web.Models.DTO
 {
@@ -19,5 +20,6 @@ namespace Registry.Web.Models.DTO
         public DateTime End { get; set; }
         public long TotalSize { get; set; }
         public int ObjectsCount { get; set; }
+        public BatchStatus Status { get; set; }
     }
 }

--- a/Registry.Web/Services/Adapters/ObjectsManager.cs
+++ b/Registry.Web/Services/Adapters/ObjectsManager.cs
@@ -199,11 +199,12 @@ namespace Registry.Web.Services.Adapters
             _logger.LogInformation($"File deleted, removing from DDB");
 
             // Remove from DDB
-            using var ddb = _ddbFactory.GetDdb(orgSlug, dsSlug);
-            ddb.Remove(path);
+            using (var ddb = _ddbFactory.GetDdb(orgSlug, dsSlug)) {
+                ddb.Remove(path);
+                dataset.UpdateStatistics(ddb);
+            }
 
             // Refresh objects count and total size
-            dataset.UpdateStatistics(ddb);
             await _context.SaveChangesAsync();
 
             _logger.LogInformation("Removed from DDB");

--- a/Registry.Web/Services/Adapters/ShareManager.cs
+++ b/Registry.Web/Services/Adapters/ShareManager.cs
@@ -63,6 +63,7 @@ namespace Registry.Web.Services.Adapters
                               Start = batch.Start,
                               Token = batch.Token,
                               UserName = batch.UserName,
+                              Status = batch.Status,
                               Entries = from entry in batch.Entries
                                         select new EntryDto
                                         {
@@ -130,10 +131,14 @@ namespace Registry.Web.Services.Adapters
 
                 await _context.Entry(dataset).Collection(item => item.Batches).LoadAsync();
 
-                if (dataset.Batches.Any(item => item.End == null))
+                var runningBatches = dataset.Batches.Where(item => item.End == null).ToArray();
+
+                if (runningBatches.Any())
                 {
-                    _logger.LogInformation("Found already running batches, cannot start a new one");
-                    throw new BadRequestException("Cannot start a new batch if there are others already running");
+                    _logger.LogInformation($"Found '{runningBatches.Length}' running batch(es), stopping and rolling back before starting a new one");
+
+                    Array.ForEach(runningBatches, RollbackBatch);
+
                 }
             }
 
@@ -142,7 +147,8 @@ namespace Registry.Web.Services.Adapters
                 Dataset = dataset,
                 Start = DateTime.Now,
                 Token = CommonUtils.RandomString(TokenLength),
-                UserName = await _authManager.SafeGetCurrentUserName()
+                UserName = await _authManager.SafeGetCurrentUserName(),
+                Status = BatchStatus.Running
             };
 
             _logger.LogInformation($"Adding new batch for user '{batch.UserName}' with token '{batch.Token}'");
@@ -153,6 +159,32 @@ namespace Registry.Web.Services.Adapters
             _logger.LogInformation("Batch created, it is now possible to upload files");
 
             return batch.Token;
+        }
+
+        private void RollbackBatch(Batch batch)
+        {
+            _logger.LogInformation($"Rolling back batch '{batch.Token}'");
+            
+            // I know we will have concurrency problems because we could be in the middle of the rollback when another client calls for it
+            // To mitigate this we are going to commit the status change of the batch as soon as possible
+
+            batch.Status = BatchStatus.Rolledback;
+            _context.SaveChanges();
+
+            _context.Entry(batch).Collection(item => item.Entries).Load();
+            _context.Entry(batch).Reference(item => item.Dataset).Load();
+            
+            var ds = batch.Dataset;
+            
+            _context.Entry(ds).Reference(item => item.Organization).Load();
+            var org = ds.Organization;
+
+            foreach (var entry in batch.Entries)
+            {
+                _objectsManager.Delete(org.Slug, ds.Slug, entry.Path);
+            }
+            
+
         }
 
 
@@ -175,7 +207,7 @@ namespace Registry.Web.Services.Adapters
             if (batch == null)
                 throw new NotFoundException("Cannot find batch");
 
-            if (batch.End != null)
+            if (batch.Status != BatchStatus.Running)
                 throw new BadRequestException("Cannot upload file to closed batch");
 
             var currentUserName = await _authManager.SafeGetCurrentUserName();
@@ -227,7 +259,7 @@ namespace Registry.Web.Services.Adapters
 
         }
 
-        public async Task<CommitResultDto> Commit(string token)
+        public async Task<CommitResultDto> Commit(string token, bool rollback = false)
         {
 
             if (string.IsNullOrWhiteSpace(token))
@@ -238,7 +270,7 @@ namespace Registry.Web.Services.Adapters
             if (batch == null)
                 throw new NotFoundException("Cannot find batch");
 
-            if (batch.End != null)
+            if (batch.Status != BatchStatus.Running)
                 throw new BadRequestException("Cannot commit a closed batch");
 
             var currentUserName = await _authManager.SafeGetCurrentUserName();
@@ -248,9 +280,27 @@ namespace Registry.Web.Services.Adapters
 
             batch.End = DateTime.Now;
 
-            _logger.LogInformation($"Committing batch '{token}' @ {batch.End.Value.ToLongDateString()} {batch.End.Value.ToLongTimeString()}");
+            if (rollback)
+            {
+                _logger.LogInformation($"Rolling back batch '{token}' @ {batch.End.Value.ToLongDateString()} {batch.End.Value.ToLongTimeString()}");
 
-            // TODO: Commit?
+                RollbackBatch(batch);
+
+                _logger.LogInformation($"Batch '{token}' rolled back");
+
+                batch.Status = BatchStatus.Rolledback;
+            }
+            else
+            {
+                _logger.LogInformation($"Committing batch '{token}' @ {batch.End.Value.ToLongDateString()} {batch.End.Value.ToLongTimeString()}");
+
+                batch.Status = BatchStatus.Committed;
+
+                // TODO: Are we supposed to do more operations here?
+
+                _logger.LogInformation($"Batch '{token}' committed");
+
+            }
 
             await _context.SaveChangesAsync();
 
@@ -261,7 +311,8 @@ namespace Registry.Web.Services.Adapters
                 End = batch.End.Value,
                 Start = batch.Start,
                 ObjectsCount = batch.Entries.Count,
-                TotalSize = batch.Entries.Sum(item => item.Size)
+                TotalSize = batch.Entries.Sum(item => item.Size),
+                Status = batch.Status
             };
 
         }

--- a/Registry.Web/Services/Adapters/ShareManager.cs
+++ b/Registry.Web/Services/Adapters/ShareManager.cs
@@ -283,7 +283,7 @@ namespace Registry.Web.Services.Adapters
             {
                 _logger.LogInformation($"Rolling back batch '{token}' @ {batch.End.Value.ToLongDateString()} {batch.End.Value.ToLongTimeString()}");
 
-                RollbackBatch(batch);
+                await RollbackBatch(batch);
 
                 _logger.LogInformation($"Batch '{token}' rolled back");
 

--- a/Registry.Web/Services/Ports/IShareManager.cs
+++ b/Registry.Web/Services/Ports/IShareManager.cs
@@ -10,7 +10,7 @@ namespace Registry.Web.Services.Ports
     {
         public Task<string> Initialize(ShareInitDto parameters);
         public Task<UploadResultDto> Upload(string token, string path, byte[] data);
-        public Task<CommitResultDto> Commit(string token);
+        public Task<CommitResultDto> Commit(string token, bool rollback = false);
         Task<IEnumerable<BatchDto>> ListBatches(string orgSlug, string dsSlug);
     }
 }


### PR DESCRIPTION
A second call to share init endpoint will cancel all the work done by the previous running batch and start fresh.
Improved happy path test and added a new one to address this specific behaviour.

Closes #40 