### PR TITLE
Return relative URL from /share/commit

### DIFF
--- a/Registry.Web.Test/ShareManagerTest.cs
+++ b/Registry.Web.Test/ShareManagerTest.cs
@@ -186,9 +186,7 @@ namespace Registry.Web.Test
             // Commit
             var commitRes = await shareManager.Commit(token);
 
-            commitRes.TotalSize.Should().Be(fileSize);
-            commitRes.ObjectsCount.Should().Be(1);
-            commitRes.Status.Should().Be(BatchStatus.Committed);
+            commitRes.Url.Should().Be(String.Format("/r/{0}/{1}", organizationTestSlug, datasetTestSlug));
 
             // ListBatches
             batches = (await shareManager.ListBatches(organizationTestSlug, datasetTestSlug)).ToArray();
@@ -330,9 +328,7 @@ namespace Registry.Web.Test
             // Commit
             var commitRes = await shareManager.Commit(newToken);
 
-            commitRes.TotalSize.Should().Be(fileSize);
-            commitRes.ObjectsCount.Should().Be(1);
-            commitRes.Status.Should().Be(BatchStatus.Committed);
+            commitRes.Url.Should().Be(String.Format("/r/{0}/{1}", organizationTestSlug, datasetTestSlug));
 
             // ListBatches
             batches = (await shareManager.ListBatches(organizationTestSlug, datasetTestSlug)).ToArray();

--- a/Registry.Web/Models/DTO/UploadResultDto.cs
+++ b/Registry.Web/Models/DTO/UploadResultDto.cs
@@ -16,10 +16,6 @@ namespace Registry.Web.Models.DTO
 
     public class CommitResultDto
     {
-        public DateTime Start { get; set; }
-        public DateTime End { get; set; }
-        public long TotalSize { get; set; }
-        public int ObjectsCount { get; set; }
-        public BatchStatus Status { get; set; }
+        public string Url { get; set; }
     }
 }

--- a/Registry.Web/Services/Adapters/ShareManager.cs
+++ b/Registry.Web/Services/Adapters/ShareManager.cs
@@ -264,7 +264,10 @@ namespace Registry.Web.Services.Adapters
             if (string.IsNullOrWhiteSpace(token))
                 throw new BadRequestException("Missing token");
 
-            var batch = _context.Batches.FirstOrDefault(item => item.Token == token);
+            var batch = _context.Batches
+                .Include(x => x.Dataset)
+                .Include(x => x.Dataset.Organization)
+                .FirstOrDefault(item => item.Token == token);
 
             if (batch == null)
                 throw new NotFoundException("Cannot find batch");
@@ -307,13 +310,8 @@ namespace Registry.Web.Services.Adapters
 
             return new CommitResultDto
             {
-                End = batch.End.Value,
-                Start = batch.Start,
-                ObjectsCount = batch.Entries.Count,
-                TotalSize = batch.Entries.Sum(item => item.Size),
-                Status = batch.Status
+                Url = "/r/" + batch.Dataset.Organization.Slug + "/" + batch.Dataset.Slug
             };
-
         }
     }
 }


### PR DESCRIPTION
Rationale: a user needs to know where the shared dataset is uploaded (if this is an anonymous upload, the slugs are decided by registry).

The reason for removing the other parameters is that... a client just doesn't need them? If there's a reason we should keep them, let's discuss it.

`/r/<org>/<ds>` will be built at a later time.