### PR TITLE
Auth token improvements

### DIFF
--- a/Registry.Web/Controllers/ShareController.cs
+++ b/Registry.Web/Controllers/ShareController.cs
@@ -20,15 +20,13 @@ namespace Registry.Web.Controllers
     public class ShareController : ControllerBaseEx
     {
         private readonly IShareManager _shareManager;
-        private readonly IChunkedUploadManager _chunkedUploadManager;
 
         private readonly ILogger<ShareController> _logger;
 
-        public ShareController(IShareManager shareManager, ILogger<ShareController> logger, IChunkedUploadManager chunkedUploadManager)
+        public ShareController(IShareManager shareManager, ILogger<ShareController> logger)
         {
             _shareManager = shareManager;
             _logger = logger;
-            _chunkedUploadManager = chunkedUploadManager;
         }
 
         [HttpPost("init")]

--- a/Registry.Web/Controllers/UsersController.cs
+++ b/Registry.Web/Controllers/UsersController.cs
@@ -60,6 +60,30 @@ namespace Registry.Web.Controllers
 
         }
 
+        [HttpPost("authenticate/refresh")]
+        public async Task<IActionResult> Refresh()
+        {
+
+            try
+            {
+                _logger.LogDebug($"Users controller Refresh()");
+
+                var res = await _usersManager.Refresh();
+
+                if (res == null)
+                    return Unauthorized(new ErrorResponse("Unauthorized"));
+
+                return Ok(res);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Exception in Users controller Refresh()");
+
+                return ExceptionResult(ex);
+            }
+
+        }
+
         [HttpPost]
         public async Task<IActionResult> CreateUser([FromForm] CreateUserRequest model)
         {

--- a/Registry.Web/Models/AuthenticateResponse.cs
+++ b/Registry.Web/Models/AuthenticateResponse.cs
@@ -2,20 +2,25 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Registry.Web.Models
 {
     
     public class AuthenticateResponse
     {
-        public string Id { get; set; }
-        public string Token { get; set; }
+        public string Id { get; }
+        public string Token { get; }
 
-
-        public AuthenticateResponse(User user, string token)
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Expires { get; }
+        
+        public AuthenticateResponse(User user, string token, DateTime expires)
         {
             Id = user.Id;
             Token = token;
+            Expires = expires;
         }
     }
 }

--- a/Registry.Web/Models/JwtDescriptor.cs
+++ b/Registry.Web/Models/JwtDescriptor.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Registry.Web.Models
+{
+    public class JwtDescriptor
+    {
+        public string Token { get; set; }
+        public DateTime ExpiresOn { get; set; }
+    }
+}

--- a/Registry.Web/Services/Adapters/ChunkedUploadManager.cs
+++ b/Registry.Web/Services/Adapters/ChunkedUploadManager.cs
@@ -74,9 +74,9 @@ namespace Registry.Web.Services.Adapters
 
             // Safety net
             using var mutex = new Mutex(false, $"ChunkedUploadSession-Upload-{sessionId}");
-
             if (!mutex.WaitOne(TimeSpan.FromMinutes(1)))
                 throw new InvalidOperationException($"Multiple call overlap of Upload with id {sessionId} on index {index}");
+
             try
             {
 
@@ -142,7 +142,6 @@ namespace Registry.Web.Services.Adapters
         {
             // Safety net
             using var mutex = new Mutex(false, $"ChunkedUploadSession-Close-{sessionId}");
-
             if (!mutex.WaitOne(TimeSpan.FromMinutes(1)))
                 throw new InvalidOperationException($"Multiple call overlap of CloseSession with id {sessionId}");
 

--- a/Registry.Web/Services/Ports/IUsersManager.cs
+++ b/Registry.Web/Services/Ports/IUsersManager.cs
@@ -15,5 +15,6 @@ namespace Registry.Web.Services.Ports
         Task CreateUser(string userName, string email, string password);
         Task DeleteUser(string userName);
         Task ChangePassword(string userName, string currentPassword, string newPassword);
+        Task<AuthenticateResponse> Refresh();
     }
 }


### PR DESCRIPTION
Closes #64 
Closes #65 

Added field `expires` to auth response (unix timestamp)

Added endpoint `authenticate`

`POST /users/authenticate/refresh`
No parameters, only bearer token
Returns `{id, token, expires}`

