### PR TITLE
Add cleanup uploads

### DIFF
--- a/Registry.Adapters/ObjectSystem/CachedS3ObjectSystem.cs
+++ b/Registry.Adapters/ObjectSystem/CachedS3ObjectSystem.cs
@@ -33,7 +33,7 @@ namespace Registry.Adapters.ObjectSystem
         private Dictionary<string, FileInfo> _fileInfos;
 
         // NOTE: This is thread safe as long that there is only one worker process
-        private static readonly object _sync = new();
+        private static readonly object _sync = new object();
 
         private const string SignalFileSuffix = "-pending";
         private const string BrokenFileSuffix = "-broken";

--- a/Registry.Web.Data/Migrations/20210125173654_BatchDeleteCascade.Designer.cs
+++ b/Registry.Web.Data/Migrations/20210125173654_BatchDeleteCascade.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Registry.Web.Data;
 
 namespace Registry.Web.Data.Migrations
 {
     [DbContext(typeof(RegistryContext))]
-    partial class RegistryContextModelSnapshot : ModelSnapshot
+    [Migration("20210125173654_BatchDeleteCascade")]
+    partial class BatchDeleteCascade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Registry.Web.Data/Migrations/20210125173654_BatchDeleteCascade.cs
+++ b/Registry.Web.Data/Migrations/20210125173654_BatchDeleteCascade.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Registry.Web.Data.Migrations
+{
+    public partial class BatchDeleteCascade : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Entries_Batches_BatchToken",
+                table: "Entries");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Entries_Batches_BatchToken",
+                table: "Entries",
+                column: "BatchToken",
+                principalTable: "Batches",
+                principalColumn: "Token",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Entries_Batches_BatchToken",
+                table: "Entries");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Entries_Batches_BatchToken",
+                table: "Entries",
+                column: "BatchToken",
+                principalTable: "Batches",
+                principalColumn: "Token",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Registry.Web.Data/Migrations/20210126152755_EntryAndBatchDeleteCascade.Designer.cs
+++ b/Registry.Web.Data/Migrations/20210126152755_EntryAndBatchDeleteCascade.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Registry.Web.Data;
 
 namespace Registry.Web.Data.Migrations
 {
     [DbContext(typeof(RegistryContext))]
-    partial class RegistryContextModelSnapshot : ModelSnapshot
+    [Migration("20210126152755_EntryAndBatchDeleteCascade")]
+    partial class EntryAndBatchDeleteCascade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -250,7 +252,7 @@ namespace Registry.Web.Data.Migrations
                     b.HasOne("Registry.Web.Data.Models.Dataset", "Dataset")
                         .WithMany("Batches")
                         .HasForeignKey("DatasetId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.ClientCascade)
                         .IsRequired();
 
                     b.Navigation("Dataset");
@@ -272,7 +274,7 @@ namespace Registry.Web.Data.Migrations
                     b.HasOne("Registry.Web.Data.Models.Dataset", "Dataset")
                         .WithMany("DownloadPackages")
                         .HasForeignKey("DatasetId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.ClientCascade)
                         .IsRequired();
 
                     b.Navigation("Dataset");
@@ -283,7 +285,7 @@ namespace Registry.Web.Data.Migrations
                     b.HasOne("Registry.Web.Data.Models.Batch", "Batch")
                         .WithMany("Entries")
                         .HasForeignKey("BatchToken")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.ClientCascade)
                         .IsRequired();
 
                     b.Navigation("Batch");

--- a/Registry.Web.Data/Migrations/20210126152755_EntryAndBatchDeleteCascade.cs
+++ b/Registry.Web.Data/Migrations/20210126152755_EntryAndBatchDeleteCascade.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Registry.Web.Data.Migrations
+{
+    public partial class EntryAndBatchDeleteCascade : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Batches_Datasets_DatasetId",
+                table: "Batches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_DownloadPackages_Datasets_DatasetId",
+                table: "DownloadPackages");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Batches_Datasets_DatasetId",
+                table: "Batches",
+                column: "DatasetId",
+                principalTable: "Datasets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DownloadPackages_Datasets_DatasetId",
+                table: "DownloadPackages",
+                column: "DatasetId",
+                principalTable: "Datasets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Batches_Datasets_DatasetId",
+                table: "Batches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_DownloadPackages_Datasets_DatasetId",
+                table: "DownloadPackages");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Batches_Datasets_DatasetId",
+                table: "Batches",
+                column: "DatasetId",
+                principalTable: "Datasets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DownloadPackages_Datasets_DatasetId",
+                table: "DownloadPackages",
+                column: "DatasetId",
+                principalTable: "Datasets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Registry.Web.Data/Migrations/20210126153428_FixCascadeAll.Designer.cs
+++ b/Registry.Web.Data/Migrations/20210126153428_FixCascadeAll.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Registry.Web.Data;
 
 namespace Registry.Web.Data.Migrations
 {
     [DbContext(typeof(RegistryContext))]
-    partial class RegistryContextModelSnapshot : ModelSnapshot
+    [Migration("20210126153428_FixCascadeAll")]
+    partial class FixCascadeAll
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Registry.Web.Data/Migrations/20210126153428_FixCascadeAll.cs
+++ b/Registry.Web.Data/Migrations/20210126153428_FixCascadeAll.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Registry.Web.Data.Migrations
+{
+    public partial class FixCascadeAll : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Batches_Datasets_DatasetId",
+                table: "Batches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_DownloadPackages_Datasets_DatasetId",
+                table: "DownloadPackages");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Entries_Batches_BatchToken",
+                table: "Entries");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Batches_Datasets_DatasetId",
+                table: "Batches",
+                column: "DatasetId",
+                principalTable: "Datasets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DownloadPackages_Datasets_DatasetId",
+                table: "DownloadPackages",
+                column: "DatasetId",
+                principalTable: "Datasets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Entries_Batches_BatchToken",
+                table: "Entries",
+                column: "BatchToken",
+                principalTable: "Batches",
+                principalColumn: "Token",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Batches_Datasets_DatasetId",
+                table: "Batches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_DownloadPackages_Datasets_DatasetId",
+                table: "DownloadPackages");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Entries_Batches_BatchToken",
+                table: "Entries");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Batches_Datasets_DatasetId",
+                table: "Batches",
+                column: "DatasetId",
+                principalTable: "Datasets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DownloadPackages_Datasets_DatasetId",
+                table: "DownloadPackages",
+                column: "DatasetId",
+                principalTable: "Datasets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Entries_Batches_BatchToken",
+                table: "Entries",
+                column: "BatchToken",
+                principalTable: "Batches",
+                principalColumn: "Token",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/Registry.Web.Data/RegistryContext.cs
+++ b/Registry.Web.Data/RegistryContext.cs
@@ -20,8 +20,14 @@ namespace Registry.Web.Data
             modelBuilder.Entity<FileChunk>()
                 .HasOne(chunk => chunk.Session)
                 .WithMany(session => session.Chunks)
-                .IsRequired(true)
+                .IsRequired()
                 .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder
+                .Entity<Entry>()
+                .HasOne(e => e.Batch)
+                .WithMany(e => e.Entries)
+                .OnDelete(DeleteBehavior.ClientCascade);
 
             // TODO: Need to set value comparer
             modelBuilder.Entity<DownloadPackage>()

--- a/Registry.Web.Data/RegistryContext.cs
+++ b/Registry.Web.Data/RegistryContext.cs
@@ -17,9 +17,24 @@ namespace Registry.Web.Data
             modelBuilder.Entity<Dataset>()
                 .HasIndex(ds => ds.Slug);
 
-            modelBuilder.Entity<FileChunk>()
+            modelBuilder
+                .Entity<Dataset>()
+                .HasOne(ds => ds.Organization)
+                .WithMany(org => org.Datasets)
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder
+                .Entity<FileChunk>()
                 .HasOne(chunk => chunk.Session)
                 .WithMany(session => session.Chunks)
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder
+                .Entity<Batch>()
+                .HasOne(e => e.Dataset)
+                .WithMany(e => e.Batches)
                 .IsRequired()
                 .OnDelete(DeleteBehavior.Cascade);
 
@@ -27,8 +42,16 @@ namespace Registry.Web.Data
                 .Entity<Entry>()
                 .HasOne(e => e.Batch)
                 .WithMany(e => e.Entries)
-                .OnDelete(DeleteBehavior.ClientCascade);
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Cascade);
 
+            modelBuilder
+                .Entity<DownloadPackage>()
+                .HasOne(e => e.Dataset)
+                .WithMany(e => e.DownloadPackages)
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Cascade);
+            
             // TODO: Need to set value comparer
             modelBuilder.Entity<DownloadPackage>()
                 .Property(e => e.Paths)

--- a/Registry.Web/Controllers/SystemController.cs
+++ b/Registry.Web/Controllers/SystemController.cs
@@ -43,6 +43,23 @@ namespace Registry.Web.Controllers
             }
         }
 
+        [HttpPost("cleanupbatches", Name = nameof(SystemController) + "." + nameof(CleanupBatches))]
+        public async Task<IActionResult> CleanupBatches()
+        {
+            try
+            {
+                _logger.LogDebug($"System controller CleanupBatches()");
+
+                return Ok(await _systemManager.CleanupBatches());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Exception in System controller CleanupBatches()");
+
+                return ExceptionResult(ex);
+            }
+        }
+
 
         [HttpPost("syncddb", Name = nameof(SystemController) + "." + nameof(SyncDdbMeta))]
         public async Task<IActionResult> SyncDdbMeta(string[] orgs)

--- a/Registry.Web/Controllers/SystemController.cs
+++ b/Registry.Web/Controllers/SystemController.cs
@@ -26,7 +26,7 @@ namespace Registry.Web.Controllers
             _logger = logger;
         }
 
-        [HttpGet("cleanupsessions", Name = nameof(SystemController) + "." + nameof(CleanupSessions))]
+        [HttpPost("cleanupsessions", Name = nameof(SystemController) + "." + nameof(CleanupSessions))]
         public async Task<IActionResult> CleanupSessions()
         {
             try

--- a/Registry.Web/Models/Configuration/AppSettings.cs
+++ b/Registry.Web/Models/Configuration/AppSettings.cs
@@ -65,6 +65,11 @@ namespace Registry.Web.Models.Configuration
         public int BatchTokenLength { get; set; }
 
         /// <summary>
+        /// Timeout of batch uploads
+        /// </summary>
+        public TimeSpan UploadBatchTimeout { get; set; }
+
+        /// <summary>
         /// Length of the random generated dataset name
         /// </summary>
         public int RandomDatasetNameLength { get; set; }

--- a/Registry.Web/Models/DTO/RemovedBatchDto.cs
+++ b/Registry.Web/Models/DTO/RemovedBatchDto.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Registry.Web.Data.Models;
+
+namespace Registry.Web.Models.DTO
+{
+
+    public class CleanupBatchesResultDto
+    {
+        public RemovedBatchDto[] RemovedBatches { get; set; }
+        
+        public RemoveBatchErrorDto[] RemoveBatchErrors { get; set; }
+    }
+
+
+    public class RemoveBatchErrorDto
+    {
+        public string Token { get; set; }
+        public string Organization { get; set; }
+        public string Dataset { get; set; }
+
+        public string Message { get; set; }
+    }
+    public class RemovedBatchDto
+    {
+        public string Token { get; set; }
+        public string UserName { get; set; }
+        public BatchStatus Status { get; set; }
+        public DateTime Start { get; set; }
+        public DateTime? End { get; set; }
+
+        public string Organization { get; set; }
+        public string Dataset { get; set; }
+
+    }
+}

--- a/Registry.Web/Services/Ports/ISystemManager.cs
+++ b/Registry.Web/Services/Ports/ISystemManager.cs
@@ -12,7 +12,7 @@ namespace Registry.Web.Services.Ports
         public Task<CleanupResult> CleanupSessions();
         public Task SyncDdbMeta(string[] orgs = null, bool skipAuthCheck = false);
 
-        // This is a hard reference and a violation of our architecture. Keeping it simple by now.
         public SyncFilesResDto SyncFiles();
+        public Task<CleanupBatchesResultDto> CleanupBatches();
     }
 }

--- a/Registry.Web/appsettings-default.json
+++ b/Registry.Web/appsettings-default.json
@@ -16,10 +16,11 @@
       "UserName": "admin",
       "Password": "password"
     },
-    "DdbStoragePath": "./App_Data/ddb",
+    "DdbStoragePath": "./ddbstore",
     "MaxRequestBodySize": 52428800,
     "MaxUploadChunkSize": 512000,
     "ChunkedUploadSessionTimeout": "01:00:00",
+    "UploadBatchTimeout": "01:00:00",
     "SupportedDdbVersion": {
       "Major": 0,
       "Minor": 9,

--- a/Registry.Web/appsettings.Release.json
+++ b/Registry.Web/appsettings.Release.json
@@ -27,6 +27,7 @@
     "MaxUploadChunkSize": 512000,
     "MaxRequestBodySize": 52428800,
     "ChunkedUploadSessionTimeout": "01:00:00",
+    "UploadBatchTimeout": "01:00:00",
     "SupportedDdbVersion": {
       "Major": 0,
       "Minor": 9,

--- a/Registry.Web/appsettings.json
+++ b/Registry.Web/appsettings.json
@@ -19,6 +19,7 @@
     "MaxRequestBodySize": 52428800,
     "MaxUploadChunkSize": 10240000,
     "BatchTokenLength": 32,
+    "UploadBatchTimeout": "00:00:30",
     "RandomDatasetNameLength": 16,
     "UploadPath": "./uploads",
     "ChunkedUploadSessionTimeout": "01:00:00",

--- a/Registry.Web/appsettings.json
+++ b/Registry.Web/appsettings.json
@@ -19,7 +19,7 @@
     "MaxRequestBodySize": 52428800,
     "MaxUploadChunkSize": 10240000,
     "BatchTokenLength": 32,
-    "UploadBatchTimeout": "00:00:30",
+    "UploadBatchTimeout": "06:00:00",
     "RandomDatasetNameLength": 16,
     "UploadPath": "./uploads",
     "ChunkedUploadSessionTimeout": "01:00:00",


### PR DESCRIPTION
Closes #71 
Added `/sys/cleanupbatches` endpoint that removes all the completed and expired batches. The setting `UploadBatchTimeout` specifies how long can a batch run before being considered "stalled" or "cancelled"