### PR TITLE
Add clone support

### DIFF
--- a/Registry.Adapters.DroneDB/Ddb.cs
+++ b/Registry.Adapters.DroneDB/Ddb.cs
@@ -23,7 +23,6 @@ namespace Registry.Adapters.DroneDB
 
     public class Ddb : IDdb
     {
-        public readonly string DdbPath;
 
         public Ddb(string ddbPath)
         {
@@ -33,8 +32,8 @@ namespace Registry.Adapters.DroneDB
 
             if (!Directory.Exists(ddbPath))
                 throw new ArgumentException($"Path '{ddbPath}' does not exist");
-            
-            DdbPath = ddbPath;
+
+            FolderPath = ddbPath;
 
         }
 
@@ -55,16 +54,17 @@ namespace Registry.Adapters.DroneDB
         {
             try
             {
-                var res = DDB.Bindings.DroneDB.Init(DdbPath);
+                var res = DDB.Bindings.DroneDB.Init(FolderPath);
                 Debug.WriteLine(res);
             }
             catch (DDBException ex)
             {
-                throw new InvalidOperationException($"Cannot initialize ddb in folder '{DdbPath}'", ex);
+                throw new InvalidOperationException($"Cannot initialize ddb in folder '{FolderPath}'", ex);
             }
         }
 
         public string Version => DDB.Bindings.DroneDB.GetVersion();
+        public string FolderPath { get; }
 
         static Ddb()
         {
@@ -83,12 +83,12 @@ namespace Registry.Adapters.DroneDB
 
                 // If the path is not absolute let's rebase it on ddbPath
                 if (path != null && !Path.IsPathRooted(path))
-                    path = Path.Combine(DdbPath, path);
+                    path = Path.Combine(FolderPath, path);
 
                 // If path is null we use the base ddb path
-                path ??= DdbPath;
+                path ??= FolderPath;
                 
-                var entries = DDB.Bindings.DroneDB.List(DdbPath, path, recursive);
+                var entries = DDB.Bindings.DroneDB.List(FolderPath, path, recursive);
                 
                 if (entries == null)
                 {
@@ -116,7 +116,7 @@ namespace Registry.Adapters.DroneDB
             }
             catch (DDBException ex)
             {
-                throw new InvalidOperationException($"Cannot list '{path}' to ddb '{DdbPath}'", ex);
+                throw new InvalidOperationException($"Cannot list '{path}' to ddb '{FolderPath}'", ex);
             }
 
 
@@ -134,13 +134,13 @@ namespace Registry.Adapters.DroneDB
             {
 
                 // If the path is not absolute let's rebase it on ddbPath
-                if (!Path.IsPathRooted(path)) path = Path.Combine(DdbPath, path);
+                if (!Path.IsPathRooted(path)) path = Path.Combine(FolderPath, path);
 
-                DDB.Bindings.DroneDB.Remove(DdbPath, path);
+                DDB.Bindings.DroneDB.Remove(FolderPath, path);
             }
             catch (DDBException ex)
             {
-                throw new InvalidOperationException($"Cannot remove '{path}' from ddb '{DdbPath}'", ex);
+                throw new InvalidOperationException($"Cannot remove '{path}' from ddb '{FolderPath}'", ex);
             }
         }
 
@@ -149,12 +149,12 @@ namespace Registry.Adapters.DroneDB
             try
             {
 
-                return DDB.Bindings.DroneDB.ChangeAttributes(DdbPath, attributes);
+                return DDB.Bindings.DroneDB.ChangeAttributes(FolderPath, attributes);
 
             }
             catch (DDBException ex)
             {
-                throw new InvalidOperationException($"Cannot change attributes of ddb '{DdbPath}'", ex);
+                throw new InvalidOperationException($"Cannot change attributes of ddb '{FolderPath}'", ex);
             }
         }
 
@@ -179,7 +179,7 @@ namespace Registry.Adapters.DroneDB
             try
             {
 
-                filePath = Path.Combine(DdbPath, path);
+                filePath = Path.Combine(FolderPath, path);
 
                 stream.Reset();
 
@@ -190,12 +190,12 @@ namespace Registry.Adapters.DroneDB
                     stream.CopyTo(writer);
                 }
 
-                DDB.Bindings.DroneDB.Add(DdbPath, filePath);
+                DDB.Bindings.DroneDB.Add(FolderPath, filePath);
 
             }
             catch (DDBException ex)
             {
-                throw new InvalidOperationException($"Cannot add '{path}' to ddb '{DdbPath}'", ex);
+                throw new InvalidOperationException($"Cannot add '{path}' to ddb '{FolderPath}'", ex);
             }
             finally
             {
@@ -213,7 +213,7 @@ namespace Registry.Adapters.DroneDB
 
         public override string ToString()
         {
-            return DdbPath;
+            return FolderPath;
         }
     }
 }

--- a/Registry.Ports/DroneDB/IDdb.cs
+++ b/Registry.Ports/DroneDB/IDdb.cs
@@ -23,5 +23,8 @@ namespace Registry.Ports.DroneDB
 
         void Init();
         string Version { get; }
+
+        // This could lead to problems if we plan to move ddbpath to S3 but it's good for now
+        string FolderPath { get; }
     }
 }

--- a/Registry.Web/Controllers/ObjectsController.cs
+++ b/Registry.Web/Controllers/ObjectsController.cs
@@ -68,7 +68,7 @@ namespace Registry.Web.Controllers
 
                 if (!int.TryParse(retina ? tyRaw.Replace("@2x", string.Empty) : tyRaw, out var ty))
                     throw new ArgumentException("Invalid input parameters (retina indicator should be '@2x')");
-                
+
                 var res = await _objectsManager.GenerateTile(orgSlug, dsSlug, path, tz, tx, ty, retina);
 
                 return File(res.ContentStream, res.ContentType, res.Name);
@@ -91,17 +91,21 @@ namespace Registry.Web.Controllers
             {
 
                 var paths = pathsRaw?.Split(",", StringSplitOptions.RemoveEmptyEntries);
-                bool isInline = isInlineRaw == 1;
+                var isInline = isInlineRaw == 1;
 
                 _logger.LogDebug($"Objects controller Download('{orgSlug}', '{dsSlug}', '{pathsRaw}', '{isInlineRaw}')");
 
                 var res = await _objectsManager.Download(orgSlug, dsSlug, paths);
 
-                if (!isInline)
-                    return File(res.ContentStream, res.ContentType, res.Name);
+                var fsr = new FileStreamResult(res.ContentStream, res.ContentType)
+                {
+                    FileDownloadName = res.Name
+                };
+
+                if (!isInline) return fsr;
 
                 Response.Headers.Add("Content-Disposition", "inline");
-                return File(res.ContentStream, res.ContentType);
+                return fsr;
 
             }
             catch (Exception ex)

--- a/Registry.Web/Middlewares/JwtInCookieMiddleware.cs
+++ b/Registry.Web/Middlewares/JwtInCookieMiddleware.cs
@@ -1,11 +1,9 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
-using Registry.Common;
-using Registry.Web.Models;
 using Registry.Web.Models.Configuration;
 
-namespace Registry.Web.Services
+namespace Registry.Web.Middlewares
 {
     public class JwtInCookieMiddleware : IMiddleware
     {

--- a/Registry.Web/Middlewares/TokenManagerMiddleware.cs
+++ b/Registry.Web/Middlewares/TokenManagerMiddleware.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Registry.Web.Services.Ports;
 
-namespace Registry.Web.Services
+namespace Registry.Web.Middlewares
 {
     public class TokenManagerMiddleware : IMiddleware
     {

--- a/Registry.Web/Models/DTO/FileDescriptor.cs
+++ b/Registry.Web/Models/DTO/FileDescriptor.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using MimeMapping;
+using Registry.Common;
+using Registry.Ports.ObjectSystem;
+using Registry.Web.Exceptions;
+using Registry.Web.Services.Adapters;
+using Registry.Web.Services.Ports;
+
+namespace Registry.Web.Models.DTO
+{
+    public class FileDescriptor
+    {
+        private readonly string _orgSlug;
+        private readonly Guid _internalRef;
+        private readonly string[] _paths;
+        private readonly bool _isSingle;
+        private readonly IObjectSystem _objectSystem;
+        private readonly IObjectsManager _objectManager;
+        private readonly ILogger<ObjectsManager> _logger;
+
+        public string Name { get; }
+        
+        public string ContentType { get; }
+
+        public FileDescriptor(string name, string contentType, string orgSlug, Guid internalRef, string[] paths,
+            bool isSingle, IObjectSystem objectSystem, IObjectsManager objectManager, ILogger<ObjectsManager> logger)
+        {
+            _orgSlug = orgSlug;
+            _internalRef = internalRef;
+            _paths = paths;
+            _isSingle = isSingle;
+            _objectSystem = objectSystem;
+            _objectManager = objectManager;
+            _logger = logger;
+            Name = name;
+            ContentType = contentType;
+        }
+
+        public async Task CopyToAsync(Stream stream)
+        {
+            // If there is just one file we return it
+            if (_isSingle)
+            {
+                var filePath = _paths.First();
+
+                _logger.LogInformation($"Only one path found: '{filePath}'");
+                
+                await WriteObjectContentStream(_orgSlug, _internalRef, filePath, stream);
+
+            }
+            // Otherwise we zip everything together and return the package
+            else
+            {
+                using var archive = new ZipArchive(stream, ZipArchiveMode.Create, true);
+                foreach (var path in _paths)
+                {
+                    _logger.LogInformation($"Zipping: '{path}'");
+
+                    var entry = archive.CreateEntry(path, CompressionLevel.Fastest);
+                    await using var entryStream = entry.Open();
+
+                    await WriteObjectContentStream(_orgSlug, _internalRef, path, entryStream);
+                }
+            }
+
+        }
+
+        private async Task WriteObjectContentStream(string orgSlug, Guid internalRef, string path, Stream stream)
+        {
+            var bucketName = _objectManager.GetBucketName(orgSlug, internalRef);
+
+            _logger.LogInformation($"Using bucket '{bucketName}'");
+
+            var bucketExists = await _objectSystem.BucketExistsAsync(bucketName);
+
+            if (!bucketExists)
+                throw new NotFoundException($"Cannot find bucket '{bucketName}'");
+
+            var objInfo = await _objectSystem.GetObjectInfoAsync(bucketName, path);
+
+            if (objInfo == null)
+                throw new NotFoundException($"Cannot find '{path}' in storage provider");
+
+            _logger.LogInformation($"Getting object '{path}' in bucket '{bucketName}'");
+
+            await _objectSystem.GetObjectAsync(bucketName, path, s => s.CopyTo(stream));
+
+        }
+    }
+}

--- a/Registry.Web/Models/DTO/FileDescriptor.cs
+++ b/Registry.Web/Models/DTO/FileDescriptor.cs
@@ -12,6 +12,7 @@ using Registry.Ports.ObjectSystem;
 using Registry.Web.Exceptions;
 using Registry.Web.Services.Adapters;
 using Registry.Web.Services.Ports;
+using Registry.Web.Utilities;
 
 namespace Registry.Web.Models.DTO
 {
@@ -30,13 +31,14 @@ namespace Registry.Web.Models.DTO
         private readonly IObjectSystem _objectSystem;
         private readonly IObjectsManager _objectManager;
         private readonly ILogger<ObjectsManager> _logger;
+        private readonly IDdbManager _ddbManager;
 
         public string Name { get; }
         
         public string ContentType { get; }
 
         public FileDescriptor(string name, string contentType, string orgSlug, Guid internalRef, string[] paths,
-            FileDescriptorType descriptorType, IObjectSystem objectSystem, IObjectsManager objectManager, ILogger<ObjectsManager> logger)
+            FileDescriptorType descriptorType, IObjectSystem objectSystem, IObjectsManager objectManager, ILogger<ObjectsManager> logger, IDdbManager ddbManager)
         {
             _orgSlug = orgSlug;
             _internalRef = internalRef;
@@ -45,6 +47,7 @@ namespace Registry.Web.Models.DTO
             _objectSystem = objectSystem;
             _objectManager = objectManager;
             _logger = logger;
+            _ddbManager = ddbManager;
             Name = name;
             ContentType = contentType;
         }
@@ -75,9 +78,13 @@ namespace Registry.Web.Models.DTO
                     await WriteObjectContentStream(_orgSlug, _internalRef, path, entryStream);
                 }
 
+                // Include ddb folder
                 if (_descriptorType == FileDescriptorType.Dataset)
                 {
-                    // TODO: Include DDB
+                    var ddb = _ddbManager.Get(_orgSlug, _internalRef);
+
+                    archive.CreateEntryFromAny(Path.Combine(ddb.FolderPath, _ddbManager.DdbFolderName));
+                    
                 }
             }
 

--- a/Registry.Web/Models/DTO/FileDescriptorDto.cs
+++ b/Registry.Web/Models/DTO/FileDescriptorDto.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace Registry.Web.Models.DTO
 {
@@ -11,4 +10,5 @@ namespace Registry.Web.Models.DTO
         public Stream ContentStream { get; set; }
         public string ContentType { get; set; }
     }
+
 }

--- a/Registry.Web/Services/Adapters/DdbManager.cs
+++ b/Registry.Web/Services/Adapters/DdbManager.cs
@@ -18,6 +18,8 @@ namespace Registry.Web.Services.Adapters
         private readonly ILogger<DdbManager> _logger;
         private readonly AppSettings _settings;
 
+        public string DdbFolderName { get; } = ".ddb";
+
         public DdbManager(IOptions<AppSettings> settings, ILogger<DdbManager> logger)
         {
             _logger = logger;
@@ -33,7 +35,7 @@ namespace Registry.Web.Services.Adapters
             var ddb = new Ddb(baseDdbPath);
 
             // TODO: It would be nice if we could use the bindings to check this
-            if (!Directory.Exists(Path.Combine(baseDdbPath, ".ddb")))
+            if (!Directory.Exists(Path.Combine(baseDdbPath, DdbFolderName)))
             {
 
                 ddb.Init();

--- a/Registry.Web/Services/Adapters/ObjectsManager.cs
+++ b/Registry.Web/Services/Adapters/ObjectsManager.cs
@@ -644,6 +644,7 @@ namespace Registry.Web.Services.Adapters
                     ContentType = MimeUtility.GetMimeMapping(filePath)
                 };
 
+                //WriteObjectContentStream(orgSlug, internalRef, filePath, descriptor.ContentStream);
                 await WriteObjectContentStream(orgSlug, internalRef, filePath, descriptor.ContentStream);
 
                 descriptor.ContentStream.Reset();
@@ -666,6 +667,8 @@ namespace Registry.Web.Services.Adapters
 
                         var entry = archive.CreateEntry(path, CompressionLevel.Fastest);
                         await using var entryStream = entry.Open();
+
+                        //WriteObjectContentStream(orgSlug, internalRef, path, entryStream);
                         await WriteObjectContentStream(orgSlug, internalRef, path, entryStream);
                     }
                 }
@@ -685,13 +688,14 @@ namespace Registry.Web.Services.Adapters
             var bucketExists = await _objectSystem.BucketExistsAsync(bucketName);
 
             if (!bucketExists)
-            {
-                _logger.LogInformation("Bucket does not exist, creating it");
+                throw new NotFoundException($"Cannot find bucket '{bucketName}'");
 
-                await _objectSystem.MakeBucketAsync(bucketName, SafeGetRegion());
-
-                _logger.LogInformation("Bucket created");
-            }
+            //if (!bucketExists)
+            //{
+            //    _logger.LogInformation("Bucket does not exist, creating it");
+            //    await _objectSystem.MakeBucketAsync(bucketName, SafeGetRegion());
+            //    _logger.LogInformation("Bucket created");
+            //}
 
             var objInfo = await _objectSystem.GetObjectInfoAsync(bucketName, path);
 

--- a/Registry.Web/Services/Adapters/ObjectsManager.cs
+++ b/Registry.Web/Services/Adapters/ObjectsManager.cs
@@ -603,6 +603,8 @@ namespace Registry.Web.Services.Adapters
 
             string[] filePaths;
 
+            bool includeDdb = false;
+
             if (paths != null)
             {
                 var temp = new List<string>();
@@ -635,6 +637,9 @@ namespace Registry.Web.Services.Adapters
 
                 if (filePaths == null)
                     throw new InvalidOperationException("Ddb is empty, what should I get?");
+
+                // We include the ddb folder only when asked for the entire dataset
+                includeDdb = true;
             }
 
             _logger.LogInformation($"Found {filePaths.Length} paths");
@@ -649,15 +654,17 @@ namespace Registry.Web.Services.Adapters
                 _logger.LogInformation($"Only one path found: '{filePath}'");
 
                 descriptor = new FileDescriptor(Path.GetFileName(filePath), MimeUtility.GetMimeMapping(filePath),
-                    orgSlug, internalRef, filePaths, true, _objectSystem, this, _logger);
+                    orgSlug, internalRef, filePaths, FileDescriptorType.Single, _objectSystem, this, _logger);
 
             }
             // Otherwise we zip everything together and return the package
             else
             {
                 descriptor = new FileDescriptor($"{orgSlug}-{dsSlug}-{CommonUtils.RandomString(8)}.zip",
-                    "application/zip", orgSlug, internalRef, filePaths, false, _objectSystem, this, _logger);
-    
+                    "application/zip", orgSlug, internalRef, filePaths,
+                    includeDdb ? FileDescriptorType.Dataset : FileDescriptorType.Multiple, _objectSystem, this,
+                    _logger);
+
             }
 
             return descriptor;

--- a/Registry.Web/Services/Adapters/ObjectsManager.cs
+++ b/Registry.Web/Services/Adapters/ObjectsManager.cs
@@ -583,7 +583,7 @@ namespace Registry.Web.Services.Adapters
 
             EnsurePathsValidity(orgSlug, ds.InternalRef, paths);
 
-            return await GetFileDescriptor(orgSlug, dsSlug, ds.InternalRef, paths);
+            return GetFileDescriptor(orgSlug, dsSlug, ds.InternalRef, paths);
         }
 
         public async Task<FileDescriptorDto> Download(string orgSlug, string dsSlug, string[] paths)
@@ -597,7 +597,7 @@ namespace Registry.Web.Services.Adapters
             return await GetOfflineFileDescriptor(orgSlug, dsSlug, ds.InternalRef, paths);
         }
 
-        private async Task<FileDescriptor> GetFileDescriptor(string orgSlug, string dsSlug, Guid internalRef, string[] paths)
+        private FileDescriptor GetFileDescriptor(string orgSlug, string dsSlug, Guid internalRef, string[] paths)
         {
             var ddb = _ddbManager.Get(orgSlug, internalRef);
 
@@ -654,7 +654,7 @@ namespace Registry.Web.Services.Adapters
                 _logger.LogInformation($"Only one path found: '{filePath}'");
 
                 descriptor = new FileDescriptor(Path.GetFileName(filePath), MimeUtility.GetMimeMapping(filePath),
-                    orgSlug, internalRef, filePaths, FileDescriptorType.Single, _objectSystem, this, _logger);
+                    orgSlug, internalRef, filePaths, FileDescriptorType.Single, _objectSystem, this, _logger, _ddbManager);
 
             }
             // Otherwise we zip everything together and return the package
@@ -663,7 +663,7 @@ namespace Registry.Web.Services.Adapters
                 descriptor = new FileDescriptor($"{orgSlug}-{dsSlug}-{CommonUtils.RandomString(8)}.zip",
                     "application/zip", orgSlug, internalRef, filePaths,
                     includeDdb ? FileDescriptorType.Dataset : FileDescriptorType.Multiple, _objectSystem, this,
-                    _logger);
+                    _logger, _ddbManager);
 
             }
 

--- a/Registry.Web/Services/DistributedCacheExtensions.cs
+++ b/Registry.Web/Services/DistributedCacheExtensions.cs
@@ -9,7 +9,7 @@ namespace Registry.Web.Services
 {
     public static class DistributedCacheExtensions
     {
-        private static readonly TimeSpan DefaultExpireTime = new TimeSpan(60);
+        private static readonly TimeSpan DefaultExpireTime = new(60);
 
         public static async Task SetRecordAsync<T>(this IDistributedCache cache, string recordId, T data,
             TimeSpan? absoluteExpireTime = null, TimeSpan? unusedExpireTime = null)

--- a/Registry.Web/Services/Ports/IDdbManager.cs
+++ b/Registry.Web/Services/Ports/IDdbManager.cs
@@ -13,5 +13,7 @@ namespace Registry.Web.Services.Ports
     {
         IDdb Get(string orgSlug, Guid internalRef);
         void Delete(string orgSlug, Guid internalRef);
+
+        public string DdbFolderName { get; }
     }
 }

--- a/Registry.Web/Services/Ports/IObjectsManager.cs
+++ b/Registry.Web/Services/Ports/IObjectsManager.cs
@@ -23,9 +23,11 @@ namespace Registry.Web.Services.Ports
         Task AddToSession(string orgSlug, string dsSlug, int sessionId, int index, byte[] data);
         Task<UploadedObjectDto> CloseSession(string orgSlug, string dsSlug, int sessionId, string path);
         Task<FileDescriptorDto> Download(string orgSlug, string dsSlug, string[] paths);
+        Task<FileDescriptor> DownloadStream(string orgSlug, string dsSlug, string[] paths);
         Task<string> GetDownloadPackage(string orgSlug, string dsSlug, string[] paths, DateTime? expiration = null, bool isPublic = false);
         Task<FileDescriptorDto> DownloadPackage(string orgSlug, string dsSlug, string packageId);
         Task<FileDescriptorDto> GenerateThumbnail(string orgSlug, string dsSlug, string path, int? size, bool recreate = false);
         Task<FileDescriptorDto> GenerateTile(string orgSlug, string dsSlug, string path, int tz, int tx, int ty, bool retina);
+        string GetBucketName(string orgSlug, Guid internalRef);
     }
 }

--- a/Registry.Web/Startup.cs
+++ b/Registry.Web/Startup.cs
@@ -41,6 +41,7 @@ using Registry.Ports.ObjectSystem;
 using Registry.Web.Data;
 using Registry.Web.Data.Models;
 using Registry.Web.HealthChecks;
+using Registry.Web.Middlewares;
 using Registry.Web.Models.Configuration;
 using Registry.Web.Models.DTO;
 using Registry.Web.Services;

--- a/Registry.Web/Startup.cs
+++ b/Registry.Web/Startup.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.StaticFiles.Infrastructure;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.EntityFrameworkCore;
@@ -173,12 +174,12 @@ namespace Registry.Web
             RegisterCacheProvider(services, appSettings);
 
             services.AddHealthChecks()
-                .AddCheck<CacheHealthCheck>("Cache health check", null, new[] {"service"})
-                .AddCheck<DdbHealthCheck>("DroneDB health check", null, new[] {"service"})
-                .AddCheck<UserManagerHealthCheck>("User manager health check", null, new[] {"database"})
-                .AddDbContextCheck<RegistryContext>("Registry database health check", null, new[] {"database"})
+                .AddCheck<CacheHealthCheck>("Cache health check", null, new[] { "service" })
+                .AddCheck<DdbHealthCheck>("DroneDB health check", null, new[] { "service" })
+                .AddCheck<UserManagerHealthCheck>("User manager health check", null, new[] { "database" })
+                .AddDbContextCheck<RegistryContext>("Registry database health check", null, new[] { "database" })
                 .AddDbContextCheck<ApplicationDbContext>("Registry identity database health check", null,
-                    new[] {"database"})
+                    new[] { "database" })
                 .AddCheck<ObjectSystemHealthCheck>("Object system health check", null, new[] { "storage" })
                 .AddDiskSpaceHealthCheck(appSettings.UploadPath, "Upload path space health check", null,
                     new[] { "storage" })
@@ -232,6 +233,18 @@ namespace Registry.Web
             });
 
             services.AddHttpContextAccessor();
+
+            // If using Kestrel:
+            services.Configure<KestrelServerOptions>(options =>
+            {
+                options.AllowSynchronousIO = true;
+            });
+
+            // If using IIS:
+            services.Configure<IISServerOptions>(options =>
+            {
+                options.AllowSynchronousIO = true;
+            });
 
             // TODO: Enable when needed. Should check return object structure
             // services.AddOData();
@@ -296,6 +309,7 @@ namespace Registry.Web
                     await context.Response.WriteAsync(Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "undefined");
                 });
 
+
                 // TODO: Enable when needed
                 // endpoints.MapODataRoute("odata", "odata", GetEdmModel());
             });
@@ -332,13 +346,6 @@ namespace Registry.Web
             await systemManager.SyncDdbMeta(null, true);
 
         }
-        //private IEdmModel GetEdmModel()
-        //{
-        //    var odataBuilder = new ODataConventionModelBuilder();
-        //    odataBuilder.EntitySet<OrganizationDto>("Organizations");
-
-        //    return odataBuilder.GetEdmModel();
-        //}
 
         // NOTE: Maybe put all this as stated in https://stackoverflow.com/a/55707949
         private void SetupDatabase(IApplicationBuilder app)

--- a/Registry.Web/Utilities/Extenders.cs
+++ b/Registry.Web/Utilities/Extenders.cs
@@ -105,7 +105,7 @@ namespace Registry.Web.Utilities
         // A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
 
         // Only lowercase letters, numbers, - and _. Max length 255
-        private static readonly Regex SafeNameRegex = new Regex(@"^\w[\w\.-]{0,127}$", RegexOptions.Compiled | RegexOptions.Singleline);
+        private static readonly Regex SafeNameRegex = new(@"^\w[\w\.-]{0,127}$", RegexOptions.Compiled | RegexOptions.Singleline);
 
         /// <summary>
         /// Checks if a string is a valid slug
@@ -202,6 +202,7 @@ namespace Registry.Web.Utilities
         {
             return arr == null ? "[]" : $"[{string.Join(", ", arr)}]";
         }
+        
 
     }
 

--- a/Registry.Web/Utilities/ZipArchiveExtensions.cs
+++ b/Registry.Web/Utilities/ZipArchiveExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Registry.Web.Utilities
+{
+    public static class ZipArchiveExtension
+    {
+
+        public static void CreateEntryFromAny(this ZipArchive archive, string sourceName, string entryName = "")
+        {
+            var fileName = Path.GetFileName(sourceName);
+            if (File.GetAttributes(sourceName).HasFlag(FileAttributes.Directory))
+            {
+                archive.CreateEntryFromDirectory(sourceName, Path.Combine(entryName, fileName));
+            }
+            else
+            {
+                archive.CreateEntryFromFile(sourceName, Path.Combine(entryName, fileName), CompressionLevel.Fastest);
+            }
+        }
+
+        public static void CreateEntryFromDirectory(this ZipArchive archive, string sourceDirName, string entryName = "")
+        {
+            string[] files = Directory.GetFiles(sourceDirName).Concat(Directory.GetDirectories(sourceDirName)).ToArray();
+            //archive.CreateEntry(Path.Combine(entryName, Path.GetFileName(sourceDirName)));
+            foreach (var file in files)
+            {
+                archive.CreateEntryFromAny(file, entryName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Preparatory for https://github.com/DroneDB/DroneDB/pull/190 and https://github.com/DroneDB/DroneDB/issues/22
Closes #123 

This PR makes the download endpoint include the `.ddb` folder when called on the entire dataset (no paths specified).
Plus It now implements a streamed approach that allows the download to start immediately while the backend fetches and compresses the files.