### PR TITLE
No compression

### DIFF
--- a/Registry.Web/Models/DTO/FileStreamDescriptor.cs
+++ b/Registry.Web/Models/DTO/FileStreamDescriptor.cs
@@ -75,7 +75,7 @@ namespace Registry.Web.Models.DTO
                 {
                     _logger.LogInformation($"Zipping: '{path}'");
 
-                    var entry = archive.CreateEntry(path, CompressionLevel.Fastest);
+                    var entry = archive.CreateEntry(path, CompressionLevel.NoCompression);
                     await using var entryStream = entry.Open();
 
                     await WriteObjectContentStream(_orgSlug, _internalRef, path, entryStream);

--- a/Registry.Web/Services/Managers/ObjectsManager.cs
+++ b/Registry.Web/Services/Managers/ObjectsManager.cs
@@ -728,7 +728,7 @@ namespace Registry.Web.Services.Managers
                     {
                         _logger.LogInformation($"Zipping: '{path}'");
 
-                        var entry = archive.CreateEntry(path, CompressionLevel.Fastest);
+                        var entry = archive.CreateEntry(path, CompressionLevel.NoCompression);
                         await using var entryStream = entry.Open();
 
                         await WriteObjectContentStream(orgSlug, internalRef, path, entryStream);
@@ -862,7 +862,7 @@ namespace Registry.Web.Services.Managers
             try
             {
                 // We could do this fully in memory BUT it's not a strict requirement by now: ddb folders are not huge (yet)
-                ZipFile.CreateFromDirectory(ddb.DatabaseFolder, tempFile, CompressionLevel.Optimal, false);
+                ZipFile.CreateFromDirectory(ddb.DatabaseFolder, tempFile, CompressionLevel.NoCompression, false);
 
                 await using var s = File.OpenRead(tempFile);
                 var memory = new MemoryStream();

--- a/Registry.Web/Utilities/ZipArchiveExtensions.cs
+++ b/Registry.Web/Utilities/ZipArchiveExtensions.cs
@@ -20,7 +20,7 @@ namespace Registry.Web.Utilities
             }
             else
             {
-                archive.CreateEntryFromFile(sourceName, CommonUtils.SafeCombine(entryName, fileName), CompressionLevel.Fastest);
+                archive.CreateEntryFromFile(sourceName, CommonUtils.SafeCombine(entryName, fileName), CompressionLevel.NoCompression);
             }
         }
 


### PR DESCRIPTION
Most of the files in DroneDB are images, videos, point clouds and GeoTIFFs. None of these benefit much from compression, but compressing these files has a real toll on clone/download performance. 

We could do mime/extension based compression rules at some point in the future (for CSVs, TXT, etc.). But for now, just disable compression.﻿
