### PR TITLE
Rename Meta to Properties

### DIFF
--- a/Registry.Adapters.DroneDB/Ddb.cs
+++ b/Registry.Adapters.DroneDB/Ddb.cs
@@ -14,7 +14,6 @@ using Newtonsoft.Json.Linq;
 using Registry.Common;
 using Registry.Ports.DroneDB;
 using Registry.Ports.DroneDB.Models;
-using LineString = GeoJSON.Net.Geometry.LineString;
 using Point = GeoJSON.Net.Geometry.Point;
 using Polygon = GeoJSON.Net.Geometry.Polygon;
 
@@ -118,7 +117,7 @@ namespace Registry.Adapters.DroneDB
                     {
                         Depth = entry.Depth,
                         Hash = entry.Hash,
-                        Meta = entry.Meta,
+                        Properties = entry.Properties,
                         ModifiedTime = entry.ModifiedTime,
                         Path = entry.Path,
                         Size = entry.Size,
@@ -238,7 +237,7 @@ namespace Registry.Adapters.DroneDB
             {
                 Depth = entry.Depth,
                 Hash = entry.Hash,
-                Meta = entry.Meta,
+                Properties = entry.Properties,
                 ModifiedTime = entry.ModifiedTime,
                 Path = entry.Path,
                 Size = entry.Size,

--- a/Registry.Adapters.DroneDB/Registry.Adapters.DroneDB.csproj
+++ b/Registry.Adapters.DroneDB/Registry.Adapters.DroneDB.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DDB.Bindings" Version="1.0.17" />
+    <PackageReference Include="DDB.Bindings" Version="1.0.18" />
     <PackageReference Include="GeoJSON.Net" Version="1.2.19" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />

--- a/Registry.Ports/DroneDB/Models/DdbAttributes.cs
+++ b/Registry.Ports/DroneDB/Models/DdbAttributes.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Registry.Ports.DroneDB.Models
 {
-    public class DdbAttributes : DdbMeta
+    public class DdbAttributes : DdbProperties
     {
         private readonly IDdb _ddb;
 
@@ -18,18 +18,18 @@ namespace Registry.Ports.DroneDB.Models
         {
             get
             {
-                UpdateMeta();
+                UpdateProperties();
 
                 return base.IsPublic;
             }
-            set => SafeSetMetaField(PublicMetaField, value);
+            set => SafeSetPropertyField(PublicPropertyField, value);
         }
 
         public new int ObjectsCount
         {
             get
             {
-                UpdateMeta();
+                UpdateProperties();
 
                 return base.ObjectsCount;
             }
@@ -39,7 +39,7 @@ namespace Registry.Ports.DroneDB.Models
         {
             get
             {
-                UpdateMeta();
+                UpdateProperties();
 
                 return base.LastUpdate;
 
@@ -48,56 +48,56 @@ namespace Registry.Ports.DroneDB.Models
             {
                 if (value == null)
                 {
-                    SafeSetMetaField<long?>(LastUpdateField, null);
+                    SafeSetPropertyField<long?>(LastUpdateField, null);
                     return;
                 }
 
                 var dt = new DateTimeOffset(value.Value);
 
-                SafeSetMetaField(LastUpdateField, dt.ToUnixTimeSeconds());
+                SafeSetPropertyField(LastUpdateField, dt.ToUnixTimeSeconds());
             }
         }
 
 
-        private void UpdateMeta()
+        private void UpdateProperties()
         {
-            _meta = _ddb.GetAttributesRaw();
+            _properties = _ddb.GetAttributesRaw();
         }
 
-        private void SafeSetMetaField<T>(string field, T val)
+        private void SafeSetPropertyField<T>(string field, T val)
         {
 
-            if (_meta == null)
+            if (_properties == null)
             {
-                _meta = new Dictionary<string, object>
+                _properties = new Dictionary<string, object>
                 {
                     { field, val }
                 };
                 return;
             }
 
-            if (_meta.ContainsKey(field))
-                _meta[field] = val;
+            if (_properties.ContainsKey(field))
+                _properties[field] = val;
             else
-                _meta.Add(field, val);
+                _properties.Add(field, val);
 
-            SaveMeta();
+            SaveProperties();
 
         }
 
-        private void SaveMeta()
+        private void SaveProperties()
         {
 
             var tmp = new Dictionary<string, object>();
 
             // We can only set LastUpdate and IsPublic
-            if (_meta.ContainsKey(LastUpdateField))
-                tmp.Add(LastUpdateField, _meta[LastUpdateField]);
+            if (_properties.ContainsKey(LastUpdateField))
+                tmp.Add(LastUpdateField, _properties[LastUpdateField]);
 
-            if (_meta.ContainsKey(PublicMetaField))
-                tmp.Add(PublicMetaField, _meta[PublicMetaField]);
+            if (_properties.ContainsKey(PublicPropertyField))
+                tmp.Add(PublicPropertyField, _properties[PublicPropertyField]);
 
-            _meta = _ddb.ChangeAttributesRaw(tmp);
+            _properties = _ddb.ChangeAttributesRaw(tmp);
         }
 
 

--- a/Registry.Ports/DroneDB/Models/DdbEntry.cs
+++ b/Registry.Ports/DroneDB/Models/DdbEntry.cs
@@ -17,7 +17,7 @@ namespace Registry.Ports.DroneDB.Models
         public int Depth { get; set; }
         public long Size { get; set; }
         public EntryType Type { get; set; }
-        public Dictionary<string, object> Meta { get; set; }
+        public Dictionary<string, object> Properties { get; set; }
         public Point PointGeometry { get; set; }
         public Polygon PolygonGeometry { get; set; }
     }

--- a/Registry.Ports/DroneDB/Models/DdbProperties.cs
+++ b/Registry.Ports/DroneDB/Models/DdbProperties.cs
@@ -8,20 +8,20 @@ using Registry.Common;
 
 namespace Registry.Ports.DroneDB.Models
 {
-    public class DdbMeta
+    public class DdbProperties
     {
-        protected Dictionary<string, object> _meta;
+        protected Dictionary<string, object> _properties;
 
-        public DdbMeta(Dictionary<string, object> meta)
+        public DdbProperties(Dictionary<string, object> properties)
         {
-            _meta = meta;
+            _properties = properties;
         }
 
         public const string LastUpdateField = "mtime";
-        public const string PublicMetaField = "public";
+        public const string PublicPropertyField = "public";
         public const string ObjectsCountField = "entries";
         
-        public bool IsPublic => SafeGetMetaField<bool>(PublicMetaField);
+        public bool IsPublic => SafeGetMetaField<bool>(PublicPropertyField);
 
         public int ObjectsCount => SafeGetMetaField<int>(ObjectsCountField);
 
@@ -41,7 +41,7 @@ namespace Registry.Ports.DroneDB.Models
 
         protected T SafeGetMetaField<T>(string field)
         {
-            var res = _meta?.SafeGetValue(field);
+            var res = _properties?.SafeGetValue(field);
             if (!(res is T)) return default;
 
             return (T)res;
@@ -49,11 +49,11 @@ namespace Registry.Ports.DroneDB.Models
 
         protected string MetaRaw
         {
-            get => JsonConvert.SerializeObject(_meta);
-            set => _meta = JsonConvert.DeserializeObject<Dictionary<string, object>>(value);
+            get => JsonConvert.SerializeObject(_properties);
+            set => _properties = JsonConvert.DeserializeObject<Dictionary<string, object>>(value);
         }
 
-        public Dictionary<string, object> Meta => new(_meta);
+        public Dictionary<string, object> Properties => new(_properties);
 
 
     }

--- a/Registry.Web.Test/DatasetManagerTest.cs
+++ b/Registry.Web.Test/DatasetManagerTest.cs
@@ -63,7 +63,7 @@ namespace Registry.Web.Test
             var ddbMock = new Mock<IDdb>();
             ddbMock.Setup(x => x.GetInfo()).Returns(new DdbEntry
             {
-                Meta = new Dictionary<string, object>
+                Properties = new Dictionary<string, object>
                 {
                     {"public", true }
                 },

--- a/Registry.Web.Test/DdbFactoryTest.cs
+++ b/Registry.Web.Test/DdbFactoryTest.cs
@@ -126,7 +126,7 @@ namespace Registry.Web.Test
             res.Depth.Should().Be(expectedDepth);
             res.Size.Should().Be(expectedSize);
             res.Type.Should().Be(expectedType);
-            res.Meta.Should().BeEquivalentTo(expectedMeta);
+            res.Properties.Should().BeEquivalentTo(expectedMeta);
             res.PointGeometry.Coordinates.Latitude.Should().BeApproximately(expectedLatitude, 0.00001);
             res.PointGeometry.Coordinates.Longitude.Should().BeApproximately(expectedLongitude, 0.00001);
             res.PointGeometry.Coordinates.Altitude.Should().BeApproximately(expectedAltitude, 0.1);
@@ -179,7 +179,7 @@ namespace Registry.Web.Test
             res.Depth.Should().Be(expectedDepth);
             res.Size.Should().Be(expectedSize);
             res.Type.Should().Be(expectedType);
-            res.Meta.Should().BeEquivalentTo(expectedMeta);
+            res.Properties.Should().BeEquivalentTo(expectedMeta);
             res.PointGeometry.Coordinates.Latitude.Should().BeApproximately(expectedLatitude, 0.00001);
             res.PointGeometry.Coordinates.Longitude.Should().BeApproximately(expectedLongitude, 0.00001);
             res.PointGeometry.Coordinates.Altitude.Should().BeApproximately(expectedAltitude, 0.1);

--- a/Registry.Web.Test/ShareManagerTest.cs
+++ b/Registry.Web.Test/ShareManagerTest.cs
@@ -161,7 +161,7 @@ namespace Registry.Web.Test
             var ddbMock = new Mock<IDdb>();
             ddbMock.Setup(x => x.GetInfo()).Returns(new DdbEntry
             {
-                Meta = attributes
+                Properties = attributes
             });
             var ddbMock2 = new Mock<IDdb>();
             ddbMock2.Setup(x => x.GetAttributesRaw()).Returns(attributes);
@@ -258,7 +258,7 @@ namespace Registry.Web.Test
             var ddbMock = new Mock<IDdb>();
             ddbMock.Setup(x => x.GetInfo()).Returns(new DdbEntry
             {
-                Meta = attributes
+                Properties = attributes
             });
             var ddbMock2 = new Mock<IDdb>();
             ddbMock2.Setup(x => x.GetAttributesRaw()).Returns(attributes);
@@ -392,7 +392,7 @@ namespace Registry.Web.Test
             var ddbMock = new Mock<IDdb>();
             ddbMock.Setup(x => x.GetInfo()).Returns(new DdbEntry
             {
-                Meta = attributes
+                Properties = attributes
             });
             var ddbMock2 = new Mock<IDdb>();
             ddbMock2.Setup(x => x.GetAttributesRaw()).Returns(attributes);

--- a/Registry.Web/Models/DTO/DatasetDto.cs
+++ b/Registry.Web/Models/DTO/DatasetDto.cs
@@ -18,7 +18,7 @@ namespace Registry.Web.Models.DTO
         public DateTime CreationDate { get; set; }
         public int ObjectsCount { get; set; }
         public DateTime? LastEdit { get; set; }
-        public Dictionary<string, object> Meta { get; set; }
+        public Dictionary<string, object> Properties { get; set; }
         public bool IsPublic { get; set; }
 
         public long Size { get; set; }

--- a/Registry.Web/Models/DTO/EntryDto.cs
+++ b/Registry.Web/Models/DTO/EntryDto.cs
@@ -16,8 +16,8 @@ namespace Registry.Web.Models.DTO
         public long Size { get; set; }
         public int Depth { get; set; }
 
-        [JsonProperty("meta")]
-        public Dictionary<string, object> Meta { get; set; }
+        [JsonProperty("properties")]
+        public Dictionary<string, object> Properties { get; set; }
 
         [JsonProperty("mtime")]
         [JsonConverter(typeof(UnixDateTimeConverter))] 

--- a/Registry.Web/Services/Managers/DatasetsManager.cs
+++ b/Registry.Web/Services/Managers/DatasetsManager.cs
@@ -50,7 +50,7 @@ namespace Registry.Web.Services.Managers
             var query = from ds in org.Datasets.ToArray()
                         let ddb = _ddbManager.Get(orgSlug, ds.InternalRef)
                         let info = ddb.GetInfo()
-                        let attributes = new DdbMeta(info.Meta)
+                        let attributes = new DdbProperties(info.Properties)
                         select new DatasetDto
                         {
                             Id = ds.Id,
@@ -60,7 +60,7 @@ namespace Registry.Web.Services.Managers
                             LastEdit = attributes.LastUpdate,
                             IsPublic = attributes.IsPublic,
                             Name = ds.Name,
-                            Meta = attributes.Meta,
+                            Properties = attributes.Properties,
                             ObjectsCount = attributes.ObjectsCount,
                             Size = info.Size
                         };
@@ -85,7 +85,7 @@ namespace Registry.Web.Services.Managers
             var ddb = _ddbManager.Get(orgSlug, dataset.InternalRef);
 
             var info = ddb.GetInfo();
-            var attrs = new DdbMeta(info.Meta);
+            var attrs = new DdbProperties(info.Properties);
             
             var entry = new EntryDto
             {
@@ -94,7 +94,7 @@ namespace Registry.Web.Services.Managers
                 Size = info.Size,
                 Path = _utils.GenerateDatasetUrl(dataset),
                 Type = EntryType.DroneDb,
-                Meta = info.Meta
+                Properties = info.Properties
             };
 
 
@@ -118,8 +118,8 @@ namespace Registry.Web.Services.Managers
 
             var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
 
-            if (dataset.Meta != null) 
-                ddb.ChangeAttributesRaw(dataset.Meta);
+            if (dataset.Properties != null) 
+                ddb.ChangeAttributesRaw(dataset.Properties);
 
             var attributes = ddb.GetAttributes();
 

--- a/Registry.Web/Utilities/Extenders.cs
+++ b/Registry.Web/Utilities/Extenders.cs
@@ -70,7 +70,7 @@ namespace Registry.Web.Utilities
 
         public static DatasetDto ToDto(this Dataset dataset, DdbEntry entry)
         {
-            var attributes = new DdbMeta(entry.Meta);
+            var attributes = new DdbProperties(entry.Properties);
 
             return new()
             {
@@ -80,7 +80,7 @@ namespace Registry.Web.Utilities
                 Description = dataset.Description,
                 LastEdit = entry.ModifiedTime,
                 Name = dataset.Name,
-                Meta = entry.Meta,
+                Properties = entry.Properties,
                 ObjectsCount = attributes.ObjectsCount,
                 Size = entry.Size,
                 IsPublic = attributes.IsPublic
@@ -94,7 +94,7 @@ namespace Registry.Web.Utilities
                 Depth = obj.Depth,
                 Hash = obj.Hash,
                 Id = obj.Id,
-                Meta = obj.Meta,
+                Properties = obj.Properties,
                 ModifiedTime = obj.ModifiedTime,
                 Path = obj.Path,
                 PointGeometry = obj.PointGeometry,


### PR DESCRIPTION
Renamed Meta field to Properties. 
Support PR of https://github.com/DroneDB/DDB.Bindings/pull/15 and https://github.com/DroneDB/DroneDB/pull/273
We should change Hub accordingly (https://github.com/DroneDB/Hub/pull/44)