### PR TITLE
Modify default storage paths

### DIFF
--- a/Registry.Web/appsettings-default.json
+++ b/Registry.Web/appsettings-default.json
@@ -9,7 +9,7 @@
     "StorageProvider": {
       "Type": "Physical",
       "Settings": {
-        "Path": "./temp"
+        "Path": "./App_Data/temp"
       }
     },
     "DefaultAdmin": {
@@ -17,7 +17,7 @@
       "UserName": "admin",
       "Password": "password"
     },
-    "DdbStoragePath": "./ddbstore",
+    "DdbStoragePath": "./App_Data/ddbstore",
     "MaxRequestBodySize": null,
     "ChunkedUploadSessionTimeout": "01:00:00",
     "UploadBatchTimeout": "01:00:00",
@@ -27,7 +27,7 @@
       "Build": 4
     },
     "BatchTokenLength": 32,
-    "UploadPath": "./uploads",
+    "UploadPath": "./App_Data/uploads",
     "RandomDatasetNameLength": 16,
     "AuthCookieName": "jwtToken",
     "HostNameOverride": null,

--- a/Registry.Web/appsettings.Release.json
+++ b/Registry.Web/appsettings.Release.json
@@ -22,8 +22,8 @@
       "UserName": "admin",
       "Password": "password"
     },
-    "DdbStoragePath": "./ddbstore",
-    "UploadPath": "./uploads",
+    "DdbStoragePath": "./App_Data/ddbstore",
+    "UploadPath": "./App_Data/uploads",
     "MaxRequestBodySize": null,
     "ChunkedUploadSessionTimeout": "01:00:00",
     "UploadBatchTimeout": "01:00:00",


### PR DESCRIPTION
Stuff stored on the hard drive should be under a single directory (e.g. App_Data ?)

This makes it easy to map docker volumes or to clean-up a Registry installation.﻿
