### PR TITLE
temp --> storage default folder

### DIFF
--- a/Registry.Web/appsettings-default.json
+++ b/Registry.Web/appsettings-default.json
@@ -9,7 +9,7 @@
     "StorageProvider": {
       "Type": "Physical",
       "Settings": {
-        "Path": "./App_Data/temp"
+        "Path": "./App_Data/storage"
       }
     },
     "DefaultAdmin": {


### PR DESCRIPTION
Changes the default storage folder from `temp` (?) to `storage`. Makes more sense.﻿
