### PR TITLE
Fix ObjectsManager Delete

### DIFF
--- a/Registry.Web/Services/Managers/ObjectsManager.cs
+++ b/Registry.Web/Services/Managers/ObjectsManager.cs
@@ -389,9 +389,10 @@ namespace Registry.Web.Services.Managers
                 throw new BadRequestException($"Cannot find bucket '{bucketName}'");
 
             _logger.LogInformation("Removing from DDB");
-            ddb.Remove(path);
-
+            
             var objs = ddb.Search(path, true).ToArray();
+
+            ddb.Remove(path);
 
             foreach (var obj in objs.Where(item => item.Type != EntryType.Directory))
             {


### PR DESCRIPTION
Currently ObjectsManager.Delete does not delete any files on the file system/S3. This is becase ddb.Remove is called before ddb.Search, causing the iteration loop to be skipped.
