### PR TITLE
Add search endpoint

### DIFF
--- a/Registry.Web.Test/ObjectManagerTest.cs
+++ b/Registry.Web.Test/ObjectManagerTest.cs
@@ -150,6 +150,42 @@ namespace Registry.Web.Test
         }
 
         [Test]
+        public async Task Search_PublicDefault_ListObjects()
+        {
+            using var test = new TestFS(Test4ArchiveUrl, BaseTestFolder);
+            await using var context = GetTest1Context();
+
+            var settings = JsonConvert.DeserializeObject<AppSettings>(_settingsJson);
+
+            settings.DdbStoragePath = Path.Combine(test.TestFolder, DdbFolder);
+            _appSettingsMock.Setup(o => o.Value).Returns(settings);
+            _authManagerMock.Setup(o => o.IsUserAdmin()).Returns(Task.FromResult(true));
+
+            var webUtils = new WebUtils(_authManagerMock.Object, context, _appSettingsMock.Object,
+                _httpContextAccessorMock.Object, _ddbFactoryMock.Object);
+
+            var objectManager = new ObjectsManager(_objectManagerLogger, context, _objectSystemMock.Object, _appSettingsMock.Object,
+                new DdbManager(_appSettingsMock.Object, _ddbFactoryLogger), webUtils, _authManagerMock.Object, _cacheManagerMock.Object, _backgroundJobsProcessor);
+
+            var res = await objectManager.Search(MagicStrings.PublicOrganizationSlug, MagicStrings.DefaultDatasetSlug, "DJI*");
+
+            res.Should().HaveCount(18);
+
+            res = await objectManager.Search(MagicStrings.PublicOrganizationSlug, MagicStrings.DefaultDatasetSlug, "*1444*");
+            res.Should().HaveCount(7);
+
+            res = await objectManager.Search(MagicStrings.PublicOrganizationSlug, MagicStrings.DefaultDatasetSlug, "*438*");
+            res.Should().HaveCount(1);
+
+            res = await objectManager.Search(MagicStrings.PublicOrganizationSlug, MagicStrings.DefaultDatasetSlug, "*438*", "Sub");
+            res.Should().HaveCount(1);
+
+            res = await objectManager.Search(MagicStrings.PublicOrganizationSlug, MagicStrings.DefaultDatasetSlug, "*438*", "Sub", false);
+            res.Should().HaveCount(1);
+
+        }
+
+        [Test]
         public async Task Get_MissingFile_NotFound()
         {
 

--- a/Registry.Web/Controllers/ObjectsController.cs
+++ b/Registry.Web/Controllers/ObjectsController.cs
@@ -315,6 +315,25 @@ namespace Registry.Web.Controllers
             }
         }
 
+
+        [HttpPost("search", Name = nameof(ObjectsController) + "." + nameof(Search))]
+        public async Task<IActionResult> Search([FromRoute] string orgSlug, [FromRoute] string dsSlug, [FromForm] string query, [FromForm] string path, [FromForm] bool recursive = true)
+        {
+            try
+            {
+                _logger.LogDebug($"Objects controller Search('{orgSlug}', '{dsSlug}', '{path}')");
+
+                var res = await _objectsManager.Search(orgSlug, dsSlug, query, path, recursive);
+                return Ok(res);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Exception in Objects controller Search('{orgSlug}', '{dsSlug}', '{path}')");
+
+                return ExceptionResult(ex);
+            }
+        }
+
         [HttpPost(RoutesHelper.ObjectsRadix)]
         [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = long.MaxValue)]
         [DisableRequestSizeLimit]
@@ -430,7 +449,7 @@ namespace Registry.Web.Controllers
                 return ExceptionResult(ex);
             }
         }
-        
+
         [HttpHead("build/{hash}/{*path}", Name = nameof(ObjectsController) + "." + nameof(BuildFile))]
         public async Task<IActionResult> CheckBuildFile([FromRoute] string orgSlug, [FromRoute] string dsSlug, [FromRoute] string hash, [FromRoute] string path)
         {

--- a/Registry.Web/Services/Ports/IObjectsManager.cs
+++ b/Registry.Web/Services/Ports/IObjectsManager.cs
@@ -11,6 +11,10 @@ namespace Registry.Web.Services.Ports
     public interface IObjectsManager
     {
         Task<IEnumerable<ObjectDto>> List(string orgSlug, string dsSlug, string path = null, bool recursive = false);
+
+        Task<IEnumerable<ObjectDto>> Search(string orgSlug, string dsSlug, string query = null, string path = null,
+            bool recursive = true);
+
         Task<ObjectRes> Get(string orgSlug, string dsSlug, string path);
         Task<ObjectDto> AddNew(string orgSlug, string dsSlug, string path, byte[] data);
         Task<ObjectDto> AddNew(string orgSlug, string dsSlug, string path, Stream stream = null);


### PR DESCRIPTION
Added new search endpoint (preparatory for https://github.com/DroneDB/Hub/issues/43)

`POST ​/orgs​/{orgSlug}​/ds​/{dsSlug}​/search`

FormData parameters:

- `query`: what to look for (wildcards * and ? are supported)
- `path`: where to look for (default root / everywhere)
- `recursive`: search in subfolders of path

It returns the same entries as `/list` endpoint

Example:

```
curl -X 'POST' \
  'https://localhost:5001/orgs/admin/ds/pcj5xhojtvs3izvz/search' \
  -H 'accept: */*' \
  -H 'Content-Type: multipart/form-data' \
  -F 'query=DJI*' \
  -F 'path=' \
  -F 'recursive=true'
```

Merge this after (https://github.com/DroneDB/Registry/pull/185)