### PR TITLE
Fixed CopyObjectAsync behaviour when file is not synchronized

### DIFF
--- a/Registry.Common/CommonUtils.cs
+++ b/Registry.Common/CommonUtils.cs
@@ -243,6 +243,19 @@ namespace Registry.Common
                 return false;
             }
         }
+        
+        public static bool SafeCopy(string source, string dest, bool overwrite = true)
+        {
+            try
+            {
+                File.Copy(source, dest, overwrite);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
 
         public static bool SafeDeleteFolder(string path)
         {


### PR DESCRIPTION
There was a bug when trying to copy a file that was not syncronized yet. it is fixed now.
