### PR TITLE
Add build pending for NXS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ RUN apt update && apt install -y --fix-missing --no-install-recommends build-ess
 RUN add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
 RUN apt install -y --fix-missing --no-install-recommends ca-certificates cmake git checkinstall sqlite3 spatialite-bin libgeos-dev libgdal-dev g++-10 gcc-10 pdal libpdal-dev libzip-dev
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 1000 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+RUN apt install -y curl && curl -L https://github.com/DroneDB/libnexus/releases/download/v1.0.0/nxs-ubuntu-20.04-amd64.deb --output /tmp/nxs-ubuntu-20.04-amd64.deb && \
+    dpkg-deb -x /tmp/nxs-ubuntu-20.04-amd64.deb /usr && \
+    rm /tmp/nxs-ubuntu-20.04-amd64.deb && \
+    apt remove -y curl
 
 # Build DroneDB
 RUN git clone --recurse-submodules https://github.com/DroneDB/DroneDB.git

--- a/Registry.Adapters/DroneDB/DDBError.cs
+++ b/Registry.Adapters/DroneDB/DDBError.cs
@@ -3,6 +3,7 @@
     public enum DDBError
     {
         DDBERR_NONE = 0, // No error
-        DDBERR_EXCEPTION = 1 // Generic app exception
+        DDBERR_EXCEPTION = 1, // Generic app exception
+        DDBERR_BUILDDEPMISSING = 2
     };
 }

--- a/Registry.Adapters/DroneDB/Ddb.cs
+++ b/Registry.Adapters/DroneDB/Ddb.cs
@@ -208,6 +208,18 @@ namespace Registry.Adapters.DroneDB
             }
         }
 
+        public void BuildPending(string dest = null, bool force = false)
+        {
+            try
+            {
+                DDBWrapper.Build(DatasetFolderPath, null, dest, force, true);
+            }
+            catch (DDBException ex)
+            {
+                throw new InvalidOperationException($"Cannot build pending from ddb '{DatasetFolderPath}'", ex);
+            }
+        }
+
         public string GetTmpFolder(string path)
         {
             string fullPath = Path.Combine(DatasetFolderPath, DatabaseFolderName, TmpFolderName, path);
@@ -224,6 +236,18 @@ namespace Registry.Adapters.DroneDB
             catch (DDBException ex)
             {
                 throw new InvalidOperationException($"Cannot call IsBuildable from ddb '{DatasetFolderPath}'", ex);
+            }
+        }
+
+        public bool IsBuildPending()
+        {
+            try
+            {
+                return DDBWrapper.IsBuildPending(DatasetFolderPath);
+            }
+            catch (DDBException ex)
+            {
+                throw new InvalidOperationException($"Cannot call IsBuildPending from ddb '{DatasetFolderPath}'", ex);
             }
         }
 
@@ -478,6 +502,12 @@ namespace Registry.Adapters.DroneDB
         public async Task<bool> IsBuildableAsync(string path, CancellationToken cancellationToken = default)
         {
             return await Task<bool>.Factory.StartNew(() => IsBuildable(path), cancellationToken,
+                TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+
+        public async Task<bool> IsBuildPendingAsync(CancellationToken cancellationToken = default)
+        {
+            return await Task<bool>.Factory.StartNew(() => IsBuildPending(), cancellationToken,
                 TaskCreationOptions.LongRunning, TaskScheduler.Default);
         }
 

--- a/Registry.Ports/DroneDB/IDDB.cs
+++ b/Registry.Ports/DroneDB/IDDB.cs
@@ -62,9 +62,11 @@ namespace Registry.Ports.DroneDB
         bool EntryExists(string path);
         void Build(string path, string dest = null, bool force = false);
         void BuildAll(string dest = null, bool force = false);
+        void BuildPending(string dest = null, bool force = false);
 
         public string GetTmpFolder(string path);
         bool IsBuildable(string path);
+        bool IsBuildPending();
 
         IMetaManager Meta { get; }
         long GetSize();
@@ -90,6 +92,8 @@ namespace Registry.Ports.DroneDB
         Task BuildAsync(string path, string dest = null, bool force = false, CancellationToken cancellationToken = default);
         Task BuildAllAsync(string dest = null, bool force = false, CancellationToken cancellationToken = default);
         Task<bool> IsBuildableAsync(string path, CancellationToken cancellationToken = default);
+        Task<bool> IsBuildPendingAsync(CancellationToken cancellationToken = default);
+
         Task<long> GetSizeAsync(CancellationToken cancellationToken = default);
 
         #endregion

--- a/Registry.Web/Services/Managers/ObjectsManager.cs
+++ b/Registry.Web/Services/Managers/ObjectsManager.cs
@@ -219,9 +219,16 @@ namespace Registry.Web.Services.Managers
 
             if (await ddb.IsBuildableAsync(entry.Path))
             {
-                _logger.LogInformation("This is a point cloud, we need to build it!");
+                _logger.LogInformation("This item is buildable, build it!");
 
-                var jobId = _backgroundJob.Enqueue(() => HangfireUtils.BuildWrapper(ddb, path, true, null));
+                var jobId = _backgroundJob.Enqueue(() => HangfireUtils.BuildWrapper(ddb, path, false, null));
+
+                _logger.LogInformation("Background job id is {JobId}", jobId);
+            }else if (await ddb.IsBuildPendingAsync())
+            {
+                _logger.LogInformation("Items are pending build, retriggering build");
+
+                var jobId = _backgroundJob.Enqueue(() => HangfireUtils.BuildPendingWrapper(ddb, null));
 
                 _logger.LogInformation("Background job id is {JobId}", jobId);
             }

--- a/Registry.Web/Services/Managers/PushManager.cs
+++ b/Registry.Web/Services/Managers/PushManager.cs
@@ -272,6 +272,15 @@ namespace Registry.Web.Services.Managers
                         HangfireUtils.BuildWrapper(ddb, item.Path, false, null));
                 }
             }
+
+            if (await ddb.IsBuildPendingAsync())
+            {
+                _logger.LogInformation("Items are pending build, retriggering build");
+
+                var jobId = _backgroundJob.Enqueue(() => HangfireUtils.BuildPendingWrapper(ddb, null));
+
+                _logger.LogInformation("Background job id is {JobId}", jobId);
+            }
         }
     }
 }

--- a/Registry.Web/Utilities/HangfireUtils.cs
+++ b/Registry.Web/Utilities/HangfireUtils.cs
@@ -24,6 +24,18 @@ namespace Registry.Web.Utilities
             writeLine("Done build");
         }
 
+        public static void BuildPendingWrapper(IDDB ddb, PerformContext context)
+        {
+            Action<string> writeLine = context != null ? context.WriteLine : Console.WriteLine;
+
+            writeLine($"In BuildPendingWrapper('{ddb.DatasetFolderPath}')");
+
+            writeLine("Running build pending");
+            ddb.BuildPending();
+
+            writeLine("Done build pending");
+        }
+
         public static void SafeDelete(string path, PerformContext context)
         {
             Action<string> writeLine = context != null ? context.WriteLine : Console.WriteLine;


### PR DESCRIPTION
Adds support for retriggering pending builds.

E.g. user uploads model.obj, but model.obj depends on model.mtl, which hasn't been uploaded yet. DroneDB can keep track of pending builds and we simply check for them anytime a new file is added.

You can upload the model.mtl (and other files) at a later time, which will trigger the pending build of model.obj.
