### PR TITLE
Allows data to be shared in a specific organization

### DIFF
--- a/Registry.Web/Controllers/OrganizationsController.cs
+++ b/Registry.Web/Controllers/OrganizationsController.cs
@@ -70,6 +70,7 @@ namespace Registry.Web.Controllers
         }
 
         [HttpPost]
+        [ProducesResponseType(typeof(OrganizationDto), 201)]
         public async Task<IActionResult> Post([FromForm] OrganizationDto organization)
         {
 
@@ -91,6 +92,7 @@ namespace Registry.Web.Controllers
         }
 
         [HttpPut(RoutesHelper.OrganizationSlug)]
+        [ProducesResponseType(204)]
         public async Task<IActionResult> Put(string orgSlug, [FromForm] OrganizationDto organization)
         {
 
@@ -111,6 +113,7 @@ namespace Registry.Web.Controllers
         }
 
         [HttpDelete(RoutesHelper.OrganizationSlug)]
+        [ProducesResponseType(204)]
         public async Task<IActionResult> Delete(string orgSlug)
         {
 

--- a/Registry.Web/Controllers/ShareController.cs
+++ b/Registry.Web/Controllers/ShareController.cs
@@ -42,21 +42,22 @@ namespace Registry.Web.Controllers
         {
             try
             {
-                _logger.LogDebug("Share controller Init('{Tag}', '{DatasetName}')", parameters?.Tag, parameters?.DatasetName);
+                _logger.LogDebug("Share controller Init('{OrgSlug}', '{DsSlug}', '{DatasetName}')", parameters.OrgSlug,
+                    parameters.DsSlug, parameters?.DatasetName);
 
                 var initRes = await _shareManager.Initialize(parameters);
 
                 return Ok(initRes);
-
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Exception in Share controller Init('{Tag}', '{DatasetName}')", parameters?.Tag, parameters?.DatasetName);
+                _logger.LogError(ex, "Exception in Share controller Init('{OrgSlug}', '{DsSlug}', '{DatasetName}')", parameters.OrgSlug,
+                    parameters.DsSlug, parameters?.DatasetName);
 
                 return ExceptionResult(ex);
             }
         }
-        
+
         [HttpGet("info/{token}")]
         public async Task<IActionResult> Info(string token)
         {
@@ -67,7 +68,6 @@ namespace Registry.Web.Controllers
                 var res = await _shareManager.GetBatchInfo(token);
 
                 return Ok(res);
-
             }
             catch (Exception ex)
             {
@@ -84,8 +84,8 @@ namespace Registry.Web.Controllers
         {
             try
             {
-
-                _logger.LogDebug("Share controller Upload('{Token}', '{Path}', '{file?.FileName}')", token, path, file?.FileName);
+                _logger.LogDebug("Share controller Upload('{Token}', '{Path}', '{file?.FileName}')", token, path,
+                    file?.FileName);
 
                 if (file == null)
                     throw new ArgumentException("No file uploaded");
@@ -96,24 +96,23 @@ namespace Registry.Web.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Exception in Share controller Upload('{Token}', '{Path}', '{file?.FileName}')", token, path, file?.FileName);
+                _logger.LogError(ex, "Exception in Share controller Upload('{Token}', '{Path}', '{file?.FileName}')",
+                    token, path, file?.FileName);
 
                 return ExceptionResult(ex);
             }
         }
-        
+
         [HttpPost("commit/{token}")]
         public async Task<IActionResult> Commit(string token)
         {
             try
             {
-
                 _logger.LogDebug("Share controller Commit('{Token}')", token);
 
                 var res = await _shareManager.Commit(token);
 
                 return Ok(res);
-
             }
             catch (Exception ex)
             {
@@ -122,19 +121,17 @@ namespace Registry.Web.Controllers
                 return ExceptionResult(ex);
             }
         }
-        
+
         [HttpPost("rollback/{token}")]
         public async Task<IActionResult> Rollback(string token)
         {
             try
             {
-
                 _logger.LogDebug("Share controller Rollback('{Token}')", token);
 
                 await _shareManager.Rollback(token);
 
                 return Ok();
-
             }
             catch (Exception ex)
             {
@@ -143,6 +140,5 @@ namespace Registry.Web.Controllers
                 return ExceptionResult(ex);
             }
         }
-
     }
 }

--- a/Registry.Web/Models/DTO/ShareInitDto.cs
+++ b/Registry.Web/Models/DTO/ShareInitDto.cs
@@ -8,7 +8,8 @@ namespace Registry.Web.Models.DTO
 {
     public class ShareInitDto
     {
-        public string Tag { get; set; }
+        public string OrgSlug { get; set; }
+        public string DsSlug { get; set; }
 
         public string DatasetName { get; set; }
         

--- a/Registry.Web/Models/DTO/ShareInitResultDto.cs
+++ b/Registry.Web/Models/DTO/ShareInitResultDto.cs
@@ -8,7 +8,6 @@ namespace Registry.Web.Models.DTO
     public class ShareInitResultDto
     {
         public string Token { get; set; }
-        public long MaxUploadChunkSize { get; set; }
 
         // NOTE: Maybe useful in the future
         // public TagDto Tag { get; set; }


### PR DESCRIPTION
Needed for https://github.com/DroneDB/Hub/pull/70

The input parameters of the share init method are now:
`{ OrgSlug, DsSlug, DatasetName}`

If no parameters are presents Registry will use the user organization and a new random dataset.
If only the organization is present, Registry creates a random dataset inside that specific organization.




