### PR TITLE
Add support for basic auth in build paths

### DIFF
--- a/Registry.Web/Controllers/ObjectsController.cs
+++ b/Registry.Web/Controllers/ObjectsController.cs
@@ -22,7 +22,6 @@ namespace Registry.Web.Controllers
     {
         private readonly IObjectsManager _objectsManager;
         private readonly ILogger<ObjectsController> _logger;
-        private readonly IAuthManager _authManager;
 
         public ObjectsController(IObjectsManager datasetsManager, ILogger<ObjectsController> logger)
         {

--- a/Registry.Web/Controllers/ObjectsController.cs
+++ b/Registry.Web/Controllers/ObjectsController.cs
@@ -6,7 +6,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using MimeMapping;
 using Registry.Ports.DroneDB.Models;
+using Registry.Web.Exceptions;
 using Registry.Web.Models;
+using Registry.Web.Filters;
 using Registry.Web.Models.DTO;
 using Registry.Web.Services.Ports;
 using Registry.Web.Utilities;
@@ -20,6 +22,7 @@ namespace Registry.Web.Controllers
     {
         private readonly IObjectsManager _objectsManager;
         private readonly ILogger<ObjectsController> _logger;
+        private readonly IAuthManager _authManager;
 
         public ObjectsController(IObjectsManager datasetsManager, ILogger<ObjectsController> logger)
         {
@@ -370,6 +373,7 @@ namespace Registry.Web.Controllers
             }
         }
 
+        [ServiceFilter(typeof(BasicAuthFilter))]
         [HttpGet("build/{hash}/{*path}", Name = nameof(ObjectsController) + "." + nameof(BuildFile))]
         public async Task<IActionResult> BuildFile([FromRoute] string orgSlug, [FromRoute] string dsSlug, [FromRoute] string hash, [FromRoute] string path)
         {
@@ -382,14 +386,17 @@ namespace Registry.Web.Controllers
                 return PhysicalFile(res, MimeUtility.GetMimeMapping(res), true);
 
             }
+            catch(UnauthorizedException ex){
+                BasicAuthFilter.SendBasicAuthRequest(Response);
+                return ExceptionResult(ex);
+            }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Exception in Objects controller BuildFile('{OrgSlug}', '{DsSlug}', '{Path}')", orgSlug, dsSlug, path);
-
                 return ExceptionResult(ex);
             }
         }
 
+        [ServiceFilter(typeof(BasicAuthFilter))]
         [HttpHead("build/{hash}/{*path}", Name = nameof(ObjectsController) + "." + nameof(BuildFile))]
         public async Task<IActionResult> CheckBuildFile([FromRoute] string orgSlug, [FromRoute] string dsSlug, [FromRoute] string hash, [FromRoute] string path)
         {
@@ -400,7 +407,11 @@ namespace Registry.Web.Controllers
                 var res = await _objectsManager.CheckBuildFile(orgSlug, dsSlug, hash, path);
 
                 return res ? Ok() : NotFound();
-
+            }
+            catch (UnauthorizedException ex)
+            {
+                BasicAuthFilter.SendBasicAuthRequest(Response);
+                return ExceptionResult(ex);
             }
             catch (Exception ex)
             {

--- a/Registry.Web/Filters/BasicAuthFilter.cs
+++ b/Registry.Web/Filters/BasicAuthFilter.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Options;
+using Registry.Web.Models;
+using Registry.Web.Models.Configuration;
+using Registry.Web.Services;
+using Registry.Web.Services.Ports;
+using System;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace Registry.Web.Filters
+{
+    public class BasicAuthFilter : ActionFilterAttribute
+    {
+        IAuthManager _authManager;
+        IUsersManager _usersManager;
+        UserManager<User> _userManager;
+        AppSettings _settings;
+
+        public BasicAuthFilter(IAuthManager authManager, IUsersManager usersManager, UserManager<User> userManager, IOptions<AppSettings> settings)
+        {
+            _authManager = authManager;
+            _usersManager = usersManager;
+            _userManager = userManager;
+            _settings = settings.Value;
+        }
+
+        public static void SendBasicAuthRequest(HttpResponse response)
+        {
+            response.Headers.Add("WWW-Authenticate", "Basic realm=\"DroneDB\"");
+            response.StatusCode = 401;
+        }
+
+        override public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            HttpContext httpContext = context.HttpContext;
+
+            string authHeader = httpContext.Request.Headers["Authorization"];
+
+            try
+            {
+                if (authHeader != null && authHeader.StartsWith("Basic"))
+                {
+                    string encodedUsernamePassword = authHeader.Substring("Basic ".Length).Trim();
+                    Encoding encoding = Encoding.GetEncoding("iso-8859-1");
+                    string usernamePassword = encoding.GetString(Convert.FromBase64String(encodedUsernamePassword));
+
+                    int seperatorIndex = usernamePassword.IndexOf(':');
+
+                    var username = usernamePassword.Substring(0, seperatorIndex);
+                    var password = usernamePassword.Substring(seperatorIndex + 1);
+                    
+                    var res = await _usersManager.Authenticate(username, password);
+                    if (res != null)
+                    {
+                        var user = await _userManager.FindByNameAsync(res.Username);
+                        var isAdmin = await _userManager.IsInRoleAsync(user, ApplicationDbContext.AdminRoleName);
+
+                        httpContext.Response.Cookies.Append(_settings.AuthCookieName, res.Token);
+
+                        var identity = new ClaimsIdentity(new[]
+                        {
+                            new Claim(ClaimTypes.Name, user.Id),
+                            new Claim(ApplicationDbContext.AdminRoleName.ToLowerInvariant(), isAdmin.ToString()),
+                        }, "authenticated");
+                        var principal = new ClaimsPrincipal(identity);
+
+                        httpContext.User = principal;
+                    }
+                }
+            }
+            catch (FormatException)
+            {
+                // Invalid auth header chars
+                // Do nothing
+            }
+
+            await next();
+        }
+    }
+}

--- a/Registry.Web/Middlewares/JwtInCookieMiddleware.cs
+++ b/Registry.Web/Middlewares/JwtInCookieMiddleware.cs
@@ -22,14 +22,10 @@ namespace Registry.Web.Middlewares
 
             if (cookie != null)
             {
-
                 var authValue = "Bearer " + cookie;
 
                 if (!context.Request.Headers.ContainsKey(AuthorizationHeaderKey))
-                    context.Request.Headers.Append(AuthorizationHeaderKey, authValue);
-                else
                     context.Request.Headers[AuthorizationHeaderKey] = authValue;
-                
             }
 
             await next.Invoke(context);

--- a/Registry.Web/Services/Managers/TokenManager.cs
+++ b/Registry.Web/Services/Managers/TokenManager.cs
@@ -41,7 +41,7 @@ namespace Registry.Web.Services.Managers
             return 
                 authorizationHeader == StringValues.Empty ? 
                     request.Cookies[_appSettings.AuthCookieName] : 
-                    authorizationHeader.Single().Split(" ").Last();
+                    authorizationHeader.SingleOrDefault(h => h.StartsWith("Bearer", System.StringComparison.OrdinalIgnoreCase), "").Split(" ").Last();
         }
 
     }

--- a/Registry.Web/Services/Managers/UsersManager.cs
+++ b/Registry.Web/Services/Managers/UsersManager.cs
@@ -365,7 +365,7 @@ namespace Registry.Web.Services.Managers
             return query.ToArray();
 
         }
-        public async Task<JwtDescriptor> GenerateJwtToken(User user)
+        private async Task<JwtDescriptor> GenerateJwtToken(User user)
         {
             // generate token
             var tokenHandler = new JwtSecurityTokenHandler();

--- a/Registry.Web/Services/Managers/UsersManager.cs
+++ b/Registry.Web/Services/Managers/UsersManager.cs
@@ -365,7 +365,7 @@ namespace Registry.Web.Services.Managers
             return query.ToArray();
 
         }
-        private async Task<JwtDescriptor> GenerateJwtToken(User user)
+        public async Task<JwtDescriptor> GenerateJwtToken(User user)
         {
             // generate token
             var tokenHandler = new JwtSecurityTokenHandler();

--- a/Registry.Web/Services/Ports/IAuthManager.cs
+++ b/Registry.Web/Services/Ports/IAuthManager.cs
@@ -20,5 +20,6 @@ namespace Registry.Web.Services.Ports
 
         public Task<bool> IsOwnerOrAdmin(Dataset ds);
         public Task<bool> UserExists(string userId);
+
     }
 }

--- a/Registry.Web/Startup.cs
+++ b/Registry.Web/Startup.cs
@@ -230,6 +230,8 @@ namespace Registry.Web
             services.AddScoped<IBackgroundJobsProcessor, BackgroundJobsProcessor>();
             services.AddScoped<IMetaManager, Services.Managers.MetaManager>();
 
+            services.AddScoped<BasicAuthFilter>();
+
             services.AddSingleton<IFileSystem, FileSystem>();
             services.AddSingleton<IPasswordHasher, PasswordHasher>();
             services.AddSingleton<IBatchTokenGenerator, BatchTokenGenerator>();


### PR DESCRIPTION
This PR adds support for basic HTTP authentication (on the build endpoint only), which is required to view resources in QGIS when datasets are private.
