### PR TITLE
Fix memory leak

### DIFF
--- a/Registry.Adapters/DroneDB/NativeDdbWrapper.cs
+++ b/Registry.Adapters/DroneDB/NativeDdbWrapper.cs
@@ -73,6 +73,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_Init(directory, out var outPath) == DdbResult.Success)
             {
                 var res = Marshal.PtrToStringUTF8(outPath);
+                _DDBFree(outPath);
 
                 if (string.IsNullOrWhiteSpace(res))
                     throw new DdbException("Unable to init");
@@ -137,6 +138,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_Add(ddbPath, utf8Ptrs, paths.Length, out var output, recursive) == DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (string.IsNullOrWhiteSpace(json))
                     throw new DdbException("Unable to add");
@@ -232,6 +234,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (string.IsNullOrWhiteSpace(json))
                     throw new DdbException("Unable get info");
@@ -295,6 +298,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (lst == DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (string.IsNullOrWhiteSpace(json))
                     throw new InvalidOperationException("Unable get list");
@@ -423,6 +427,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var res = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (string.IsNullOrWhiteSpace(res))
                     throw new InvalidOperationException("Unable get attributes");
@@ -496,6 +501,9 @@ public class NativeDdbWrapper : IDdbWrapper
     private static extern DdbResult _DDBVSIFree(
         IntPtr buffer);
 
+    [DllImport("ddb", EntryPoint = "DDBFree")]
+    private static extern DdbResult _DDBFree(IntPtr ptr);
+
     [DllImport("ddb", EntryPoint = "DDBGenerateMemoryThumbnail")]
     private static extern DdbResult _GenerateMemoryThumbnail(
         [MarshalAs(UnmanagedType.LPUTF8Str)] string filePath, int size, out IntPtr outBuffer, out int outBufferSize);
@@ -556,6 +564,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var res = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (string.IsNullOrWhiteSpace(res))
                     throw new DdbException("Unable get tile path");
@@ -661,6 +670,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success) throw new DdbException(SafeGetLastError());
 
             var res = Marshal.PtrToStringUTF8(outTag);
+            _DDBFree(outTag);
 
             return res == null || string.IsNullOrWhiteSpace(res) ? null : res;
         }
@@ -690,6 +700,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBGetStamp call");
@@ -744,6 +755,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var conflicts = Marshal.PtrToStringUTF8(conflictsPtr);
+                _DDBFree(conflictsPtr);
 
                 if (string.IsNullOrWhiteSpace(conflicts))
                     throw new DdbException("Unable get applydelta result");
@@ -782,6 +794,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (string.IsNullOrWhiteSpace(json))
                     throw new InvalidOperationException("Unable get delta");
@@ -824,6 +837,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var output = Marshal.PtrToStringUTF8(outputPtr);
+                _DDBFree(outputPtr);
 
                 if (string.IsNullOrWhiteSpace(output))
                     throw new DdbException("Unable get ComputeDeltaLocals result");
@@ -989,6 +1003,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBMetaUnset call");
@@ -1028,6 +1043,8 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
+
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBMetaUnset call");
 
@@ -1065,6 +1082,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBMetaRemove call");
@@ -1105,6 +1123,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 return json;
             }
@@ -1136,6 +1155,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBMetaUnset call");
@@ -1176,6 +1196,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBMetaList call");
@@ -1214,6 +1235,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBMetaDump call");
@@ -1255,6 +1277,7 @@ public class NativeDdbWrapper : IDdbWrapper
                 DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBMetaDump call");
@@ -1295,6 +1318,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_Rescan(ddbPath, out var output, types ?? string.Empty, stopOnError) == DdbResult.Success)
             {
                 var json = Marshal.PtrToStringUTF8(output);
+                _DDBFree(output);
 
                 if (string.IsNullOrWhiteSpace(json))
                     throw new DdbException("Unable to get rescan results");

--- a/Registry.Adapters/DroneDB/NativeDdbWrapper.cs
+++ b/Registry.Adapters/DroneDB/NativeDdbWrapper.cs
@@ -72,8 +72,7 @@ public class NativeDdbWrapper : IDdbWrapper
         {
             if (_Init(directory, out var outPath) == DdbResult.Success)
             {
-                var res = Marshal.PtrToStringUTF8(outPath);
-                _DDBFree(outPath);
+                var res = MarshalAndFreeUtf8(outPath);
 
                 if (string.IsNullOrWhiteSpace(res))
                     throw new DdbException("Unable to init");
@@ -120,6 +119,13 @@ public class NativeDdbWrapper : IDdbWrapper
         }
     }
 
+    private static string? MarshalAndFreeUtf8(IntPtr ptr)
+    {
+        var str = Marshal.PtrToStringUTF8(ptr);
+        _DDBFree(ptr);
+        return str;
+    }
+
     [DllImport("ddb", EntryPoint = "DDBAdd")]
     private static extern DdbResult _Add([MarshalAs(UnmanagedType.LPUTF8Str)] string ddbPath,
         IntPtr[] paths,
@@ -137,8 +143,7 @@ public class NativeDdbWrapper : IDdbWrapper
         {
             if (_Add(ddbPath, utf8Ptrs, paths.Length, out var output, recursive) == DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (string.IsNullOrWhiteSpace(json))
                     throw new DdbException("Unable to add");
@@ -233,8 +238,7 @@ public class NativeDdbWrapper : IDdbWrapper
                     withHash) ==
                 DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (string.IsNullOrWhiteSpace(json))
                     throw new DdbException("Unable get info");
@@ -297,8 +301,7 @@ public class NativeDdbWrapper : IDdbWrapper
 
             if (lst == DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (string.IsNullOrWhiteSpace(json))
                     throw new InvalidOperationException("Unable get list");
@@ -426,8 +429,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_ChangeAttributes(ddbPath, attrs, out var output) ==
                 DdbResult.Success)
             {
-                var res = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var res = MarshalAndFreeUtf8(output);
 
                 if (string.IsNullOrWhiteSpace(res))
                     throw new InvalidOperationException("Unable get attributes");
@@ -563,8 +565,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_GenerateTile(inputPath, tz, tx, ty, out var output, tileSize, tms, forceRecreate) ==
                 DdbResult.Success)
             {
-                var res = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var res = MarshalAndFreeUtf8(output);
 
                 if (string.IsNullOrWhiteSpace(res))
                     throw new DdbException("Unable get tile path");
@@ -669,8 +670,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_GetTag(ddbPath, out var outTag) !=
                 DdbResult.Success) throw new DdbException(SafeGetLastError());
 
-            var res = Marshal.PtrToStringUTF8(outTag);
-            _DDBFree(outTag);
+            var res = MarshalAndFreeUtf8(outTag);
 
             return res == null || string.IsNullOrWhiteSpace(res) ? null : res;
         }
@@ -699,8 +699,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_DDBGetStamp(ddbPath, out var output) ==
                 DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBGetStamp call");
@@ -754,8 +753,7 @@ public class NativeDdbWrapper : IDdbWrapper
                     out var conflictsPtr) ==
                 DdbResult.Success)
             {
-                var conflicts = Marshal.PtrToStringUTF8(conflictsPtr);
-                _DDBFree(conflictsPtr);
+                var conflicts = MarshalAndFreeUtf8(conflictsPtr);
 
                 if (string.IsNullOrWhiteSpace(conflicts))
                     throw new DdbException("Unable get applydelta result");
@@ -793,8 +791,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_Delta(sourceJson, targetJson, out var output, "json") ==
                 DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (string.IsNullOrWhiteSpace(json))
                     throw new InvalidOperationException("Unable get delta");
@@ -836,8 +833,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_ComputeDeltaLocals(deltaJson, ddbPath, hlDestFolder, out var outputPtr) ==
                 DdbResult.Success)
             {
-                var output = Marshal.PtrToStringUTF8(outputPtr);
-                _DDBFree(outputPtr);
+                var output = MarshalAndFreeUtf8(outputPtr);
 
                 if (string.IsNullOrWhiteSpace(output))
                     throw new DdbException("Unable get ComputeDeltaLocals result");
@@ -1002,11 +998,10 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_MetaAdd(ddbPath, path ?? string.Empty, key, data, out var output) ==
                 DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (json == null)
-                    throw new InvalidOperationException("No result from DDBMetaUnset call");
+                    throw new InvalidOperationException("No result from DDBMetaAdd call");
 
                 var res = JsonConvert.DeserializeObject<Meta>(json);
 
@@ -1042,11 +1037,10 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_MetaSet(ddbPath, path ?? string.Empty, key, data, out var output) ==
                 DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (json == null)
-                    throw new InvalidOperationException("No result from DDBMetaUnset call");
+                    throw new InvalidOperationException("No result from DDBMetaSet call");
 
                 var res = JsonConvert.DeserializeObject<Meta>(json);
 
@@ -1081,8 +1075,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_MetaRemove(ddbPath, id, out var output) ==
                 DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBMetaRemove call");
@@ -1122,8 +1115,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_MetaGet(ddbPath, path ?? string.Empty, key, out var output) ==
                 DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 return json;
             }
@@ -1154,8 +1146,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_MetaUnset(ddbPath, path ?? string.Empty, key, out var output) ==
                 DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBMetaUnset call");
@@ -1195,8 +1186,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_MetaList(ddbPath, path ?? string.Empty, out var output) ==
                 DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBMetaList call");
@@ -1234,8 +1224,7 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_MetaDump(ddbPath, ids ?? "[]", out var output) ==
                 DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (json == null)
                     throw new InvalidOperationException("No result from DDBMetaDump call");
@@ -1276,11 +1265,10 @@ public class NativeDdbWrapper : IDdbWrapper
             if (_Stac(ddbPath, entry ?? string.Empty, stacCollectionRoot, id, stacCatalogRoot, out var output) ==
                 DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (json == null)
-                    throw new InvalidOperationException("No result from DDBMetaDump call");
+                    throw new InvalidOperationException("No result from DDBStac call");
 
                 var res = JsonConvert.DeserializeObject<JToken>(json);
 
@@ -1317,8 +1305,7 @@ public class NativeDdbWrapper : IDdbWrapper
         {
             if (_Rescan(ddbPath, out var output, types ?? string.Empty, stopOnError) == DdbResult.Success)
             {
-                var json = Marshal.PtrToStringUTF8(output);
-                _DDBFree(output);
+                var json = MarshalAndFreeUtf8(output);
 
                 if (string.IsNullOrWhiteSpace(json))
                     throw new DdbException("Unable to get rescan results");

--- a/Registry.Web/Registry.Web.csproj
+++ b/Registry.Web/Registry.Web.csproj
@@ -12,7 +12,7 @@
         <Platforms>AnyCPU;x64</Platforms>
         <PackageVersion>2.0.5</PackageVersion>
         <Configurations>Debug;Release;DebugEf</Configurations>
-        <DdbVersion>1.4.4</DdbVersion>
+        <DdbVersion>1.4.5</DdbVersion>
         <LangVersion>13</LangVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
Addresses the issue https://github.com/DroneDB/Registry/issues/334

Registry now makes use of `DDBFree` to properly release memory from `libddb`