### PR TITLE
Improve multispectral support

### DIFF
--- a/Registry.Adapters/DroneDB/Ddb.cs
+++ b/Registry.Adapters/DroneDB/Ddb.cs
@@ -485,12 +485,12 @@ public class DDB : IDDB
     {
         try
         {
-            var fullPaths = paths.Select(p => GetLocalPath(p)).ToArray();
+            var fullPaths = paths.Select(GetLocalPath).ToArray();
             _ddbWrapper.MergeMultispectral(fullPaths, outputCog);
         }
         catch (DdbException ex)
         {
-            throw new InvalidOperationException("Cannot merge multispectral", ex);
+            throw new InvalidOperationException($"Cannot merge multispectral: {ex.Message}", ex);
         }
     }
 

--- a/Registry.Adapters/DroneDB/Ddb.cs
+++ b/Registry.Adapters/DroneDB/Ddb.cs
@@ -397,4 +397,100 @@ public class DDB : IDDB
 
         Directory.CreateDirectory(BuildFolderPath);
     }
+
+    public string GetRasterInfo(string path)
+    {
+        try
+        {
+            var fullPath = GetLocalPath(path);
+            return _ddbWrapper.GetRasterInfo(fullPath);
+        }
+        catch (DdbException ex)
+        {
+            throw new InvalidOperationException($"Cannot get raster info of '{path}'", ex);
+        }
+    }
+
+    public string GetRasterMetadata(string path, string? formula = null, string? bandFilter = null)
+    {
+        try
+        {
+            var fullPath = GetLocalPath(path);
+            return _ddbWrapper.GetRasterMetadata(fullPath, formula, bandFilter);
+        }
+        catch (DdbException ex)
+        {
+            throw new InvalidOperationException($"Cannot get raster metadata of '{path}'", ex);
+        }
+    }
+
+    public byte[] GenerateThumbnailEx(string imagePath, int size, string? preset = null,
+        string? bands = null, string? formula = null, string? bandFilter = null,
+        string? colormap = null, string? rescale = null)
+    {
+        try
+        {
+            return _ddbWrapper.GenerateThumbnailEx(imagePath, size, preset, bands, formula, bandFilter,
+                colormap, rescale);
+        }
+        catch (DdbException ex)
+        {
+            throw new InvalidOperationException(
+                $"Cannot generate thumbnail ex of '{imagePath}' with size '{size}'", ex);
+        }
+    }
+
+    public byte[] GenerateTileEx(string inputPath, int tz, int tx, int ty, bool retina, string inputPathHash,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null)
+    {
+        try
+        {
+            return _ddbWrapper.GenerateMemoryTileEx(inputPath, tz, tx, ty, retina ? 512 : 256, true, false,
+                inputPathHash, preset, bands, formula, bandFilter, colormap, rescale);
+        }
+        catch (DdbException ex)
+        {
+            throw new InvalidOperationException($"Cannot generate tile ex of '{inputPath}'", ex);
+        }
+    }
+
+    public string ValidateMergeMultispectral(string[] paths)
+    {
+        try
+        {
+            var fullPaths = paths.Select(p => GetLocalPath(p)).ToArray();
+            return _ddbWrapper.ValidateMergeMultispectral(fullPaths);
+        }
+        catch (DdbException ex)
+        {
+            throw new InvalidOperationException("Cannot validate merge multispectral", ex);
+        }
+    }
+
+    public byte[] PreviewMergeMultispectral(string[] paths, string? previewBands = null, int thumbSize = 512)
+    {
+        try
+        {
+            var fullPaths = paths.Select(p => GetLocalPath(p)).ToArray();
+            return _ddbWrapper.PreviewMergeMultispectral(fullPaths, previewBands, thumbSize);
+        }
+        catch (DdbException ex)
+        {
+            throw new InvalidOperationException("Cannot preview merge multispectral", ex);
+        }
+    }
+
+    public void MergeMultispectral(string[] paths, string outputCog)
+    {
+        try
+        {
+            var fullPaths = paths.Select(p => GetLocalPath(p)).ToArray();
+            _ddbWrapper.MergeMultispectral(fullPaths, outputCog);
+        }
+        catch (DdbException ex)
+        {
+            throw new InvalidOperationException("Cannot merge multispectral", ex);
+        }
+    }
 }

--- a/Registry.Adapters/DroneDB/Ddb.cs
+++ b/Registry.Adapters/DroneDB/Ddb.cs
@@ -18,7 +18,7 @@ namespace Registry.Adapters.DroneDB;
 
 public class DDB : IDDB
 {
-    private static readonly IFileSystem FileSystem = new FileSystem();
+    private static readonly FileSystem FileSystem = new();
     private IDdbWrapper _ddbWrapper;
 
     [JsonIgnore] public string Version => _ddbWrapper.GetVersion();
@@ -459,7 +459,7 @@ public class DDB : IDDB
     {
         try
         {
-            var fullPaths = paths.Select(p => GetLocalPath(p)).ToArray();
+            var fullPaths = paths.Select(GetLocalPath).ToArray();
             return _ddbWrapper.ValidateMergeMultispectral(fullPaths);
         }
         catch (DdbException ex)
@@ -505,6 +505,45 @@ public class DDB : IDDB
         catch (DdbException ex)
         {
             throw new InvalidOperationException($"Cannot export raster '{inputPath}'", ex);
+        }
+    }
+
+    public string GetThermalInfo(string path)
+    {
+        try
+        {
+            var fullPath = GetLocalPath(path);
+            return _ddbWrapper.GetThermalInfo(fullPath);
+        }
+        catch (DdbException ex)
+        {
+            throw new InvalidOperationException($"Cannot get thermal info of '{path}'", ex);
+        }
+    }
+
+    public string GetThermalPoint(string path, int x, int y)
+    {
+        try
+        {
+            var fullPath = GetLocalPath(path);
+            return _ddbWrapper.GetThermalPoint(fullPath, x, y);
+        }
+        catch (DdbException ex)
+        {
+            throw new InvalidOperationException($"Cannot get thermal point of '{path}'", ex);
+        }
+    }
+
+    public string GetThermalAreaStats(string path, int x0, int y0, int x1, int y1)
+    {
+        try
+        {
+            var fullPath = GetLocalPath(path);
+            return _ddbWrapper.GetThermalAreaStats(fullPath, x0, y0, x1, y1);
+        }
+        catch (DdbException ex)
+        {
+            throw new InvalidOperationException($"Cannot get thermal area stats of '{path}'", ex);
         }
     }
 }

--- a/Registry.Adapters/DroneDB/Ddb.cs
+++ b/Registry.Adapters/DroneDB/Ddb.cs
@@ -493,4 +493,18 @@ public class DDB : IDDB
             throw new InvalidOperationException("Cannot merge multispectral", ex);
         }
     }
+
+    public void ExportRaster(string inputPath, string outputPath,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null)
+    {
+        try
+        {
+            _ddbWrapper.ExportRaster(inputPath, outputPath, preset, bands, formula, bandFilter, colormap, rescale);
+        }
+        catch (DdbException ex)
+        {
+            throw new InvalidOperationException($"Cannot export raster '{inputPath}'", ex);
+        }
+    }
 }

--- a/Registry.Adapters/DroneDB/Ddb.cs
+++ b/Registry.Adapters/DroneDB/Ddb.cs
@@ -472,7 +472,7 @@ public class DDB : IDDB
     {
         try
         {
-            var fullPaths = paths.Select(p => GetLocalPath(p)).ToArray();
+            var fullPaths = paths.Select(GetLocalPath).ToArray();
             return _ddbWrapper.PreviewMergeMultispectral(fullPaths, previewBands, thumbSize);
         }
         catch (DdbException ex)

--- a/Registry.Adapters/DroneDB/Ddb.cs
+++ b/Registry.Adapters/DroneDB/Ddb.cs
@@ -64,7 +64,8 @@ public class DDB : IDDB
     {
         try
         {
-            return _ddbWrapper.GenerateMemoryTile(inputPath, tz, tx, ty, retina ? 512 : 256, true, false,
+            var fullPath = GetLocalPath(inputPath);
+            return _ddbWrapper.GenerateMemoryTile(fullPath, tz, tx, ty, retina ? 512 : 256, true, false,
                 inputPathHash);
         }
         catch (DdbException ex)
@@ -97,6 +98,8 @@ public class DDB : IDDB
         return CommonUtils.SafeCombine(DatasetFolderPath, path);
     }
 
+    private static string NormalizePath(string path) => path.Replace('\\', '/');
+
     public Entry? GetEntry(string path)
     {
         var objs = Search(path, true).ToArray();
@@ -121,14 +124,9 @@ public class DDB : IDDB
     {
         try
         {
-            // If the path is not absolute let's rebase it on ddbPath
-            if (path != null && !Path.IsPathRooted(path))
-                path = Path.Combine(DatasetFolderPath, path);
+            var fullPath = path != null ? GetLocalPath(path) : DatasetFolderPath;
 
-            // If path is null we use the base ddb path
-            path ??= DatasetFolderPath;
-
-            var entries = _ddbWrapper.List(DatasetFolderPath, path, recursive);
+            var entries = _ddbWrapper.List(DatasetFolderPath, fullPath, recursive);
 
             if (entries == null)
             {
@@ -154,10 +152,9 @@ public class DDB : IDDB
     {
         try
         {
-            // If the path is not absolute let's rebase it on ddbPath
-            if (!Path.IsPathRooted(path)) path = Path.Combine(DatasetFolderPath, path);
+            var fullPath = GetLocalPath(path);
 
-            _ddbWrapper.Remove(DatasetFolderPath, path);
+            _ddbWrapper.Remove(DatasetFolderPath, fullPath);
         }
         catch (DdbException ex)
         {
@@ -169,7 +166,7 @@ public class DDB : IDDB
     {
         try
         {
-            _ddbWrapper.MoveEntry(DatasetFolderPath, source, dest);
+            _ddbWrapper.MoveEntry(DatasetFolderPath, NormalizePath(source), NormalizePath(dest));
         }
         catch (DdbException ex)
         {
@@ -182,7 +179,7 @@ public class DDB : IDDB
     {
         try
         {
-            _ddbWrapper.Build(DatasetFolderPath, path, dest, force);
+            _ddbWrapper.Build(DatasetFolderPath, path != null ? NormalizePath(path) : null, dest, force);
         }
         catch (DdbException ex)
         {
@@ -225,7 +222,7 @@ public class DDB : IDDB
     {
         try
         {
-            return _ddbWrapper.IsBuildable(DatasetFolderPath, path);
+            return _ddbWrapper.IsBuildable(DatasetFolderPath, NormalizePath(path));
         }
         catch (DdbException ex)
         {
@@ -237,7 +234,7 @@ public class DDB : IDDB
     {
         try
         {
-            return _ddbWrapper.IsBuildActive(DatasetFolderPath, path);
+            return _ddbWrapper.IsBuildActive(DatasetFolderPath, NormalizePath(path));
         }
         catch (DdbException ex)
         {
@@ -278,7 +275,8 @@ public class DDB : IDDB
     {
         try
         {
-            return _ddbWrapper.GenerateThumbnail(imagePath, size);
+            var fullPath = GetLocalPath(imagePath);
+            return _ddbWrapper.GenerateThumbnail(fullPath, size);
         }
         catch (DdbException ex)
         {
@@ -291,7 +289,8 @@ public class DDB : IDDB
     {
         try
         {
-            _ddbWrapper.Add(DatasetFolderPath, path);
+            var fullPath = GetLocalPath(path);
+            _ddbWrapper.Add(DatasetFolderPath, fullPath);
         }
         catch (DdbException ex)
         {
@@ -307,7 +306,7 @@ public class DDB : IDDB
 
             try
             {
-                folderPath = Path.Combine(DatasetFolderPath, path);
+                folderPath = GetLocalPath(path);
 
                 Directory.CreateDirectory(folderPath);
 
@@ -332,7 +331,7 @@ public class DDB : IDDB
 
             try
             {
-                filePath = Path.Combine(DatasetFolderPath, path);
+                filePath = GetLocalPath(path);
 
                 stream.SafeReset();
 
@@ -430,7 +429,8 @@ public class DDB : IDDB
     {
         try
         {
-            return _ddbWrapper.GenerateThumbnailEx(imagePath, size, preset, bands, formula, bandFilter,
+            var fullPath = GetLocalPath(imagePath);
+            return _ddbWrapper.GenerateThumbnailEx(fullPath, size, preset, bands, formula, bandFilter,
                 colormap, rescale);
         }
         catch (DdbException ex)
@@ -446,7 +446,8 @@ public class DDB : IDDB
     {
         try
         {
-            return _ddbWrapper.GenerateMemoryTileEx(inputPath, tz, tx, ty, retina ? 512 : 256, true, false,
+            var fullPath = GetLocalPath(inputPath);
+            return _ddbWrapper.GenerateMemoryTileEx(fullPath, tz, tx, ty, retina ? 512 : 256, true, false,
                 inputPathHash, preset, bands, formula, bandFilter, colormap, rescale);
         }
         catch (DdbException ex)
@@ -486,7 +487,8 @@ public class DDB : IDDB
         try
         {
             var fullPaths = paths.Select(GetLocalPath).ToArray();
-            _ddbWrapper.MergeMultispectral(fullPaths, outputCog);
+            var fullOutputCog = GetLocalPath(outputCog);
+            _ddbWrapper.MergeMultispectral(fullPaths, fullOutputCog);
         }
         catch (DdbException ex)
         {
@@ -500,7 +502,8 @@ public class DDB : IDDB
     {
         try
         {
-            _ddbWrapper.ExportRaster(inputPath, outputPath, preset, bands, formula, bandFilter, colormap, rescale);
+            var fullInputPath = GetLocalPath(inputPath);
+            _ddbWrapper.ExportRaster(fullInputPath, outputPath, preset, bands, formula, bandFilter, colormap, rescale);
         }
         catch (DdbException ex)
         {
@@ -544,6 +547,20 @@ public class DDB : IDDB
         catch (DdbException ex)
         {
             throw new InvalidOperationException($"Cannot get thermal area stats of '{path}'", ex);
+        }
+    }
+
+    public void MaskBorders(string input, string output, int nearDist = 15, bool white = false)
+    {
+        try
+        {
+            var fullInput = GetLocalPath(input);
+            var fullOutput = GetLocalPath(output);
+            _ddbWrapper.MaskBorders(fullInput, fullOutput, nearDist, white);
+        }
+        catch (DdbException ex)
+        {
+            throw new InvalidOperationException($"Cannot mask borders of '{input}'", ex);
         }
     }
 }

--- a/Registry.Adapters/DroneDB/NativeDdbWrapper.cs
+++ b/Registry.Adapters/DroneDB/NativeDdbWrapper.cs
@@ -1609,5 +1609,45 @@ public class NativeDdbWrapper : IDdbWrapper
         throw new DdbException(SafeGetLastError("merge multispectral"));
     }
 
+    [DllImport("ddb", EntryPoint = "DDBExportRaster")]
+    private static extern DdbResult _ExportRaster(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string inputPath,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string outputPath,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? preset,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? bands,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? formula,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? bandFilter,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? colormap,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? rescale);
+
+    public void ExportRaster(string inputPath, string outputPath,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null)
+    {
+        if (string.IsNullOrWhiteSpace(inputPath))
+            throw new ArgumentException("inputPath is null or empty");
+        if (string.IsNullOrWhiteSpace(outputPath))
+            throw new ArgumentException("outputPath is null or empty");
+
+        try
+        {
+            if (_ExportRaster(inputPath, outputPath, preset, bands, formula, bandFilter,
+                    colormap, rescale) == DdbResult.Success)
+                return;
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            throw new DdbException($"Error in calling ddb lib: incompatible versions ({ex.Message})", ex);
+        }
+        catch (DdbException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DdbException(
+                $"Error in calling ddb lib. Last error: \"{SafeGetLastError("export raster")}\", check inner exception for details", ex);
+        }
+
+        throw new DdbException(SafeGetLastError("export raster"));
+    }
+
     #endregion
 }

--- a/Registry.Adapters/DroneDB/NativeDdbWrapper.cs
+++ b/Registry.Adapters/DroneDB/NativeDdbWrapper.cs
@@ -1650,4 +1650,104 @@ public class NativeDdbWrapper : IDdbWrapper
     }
 
     #endregion
+
+    #region Thermal P/Invoke
+
+    [DllImport("ddb", EntryPoint = "DDBGetThermalInfo")]
+    private static extern DdbResult _GetThermalInfo(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string path, out IntPtr output);
+
+    public string GetThermalInfo(string path)
+    {
+        if (path == null) throw new ArgumentException("path is null");
+
+        try
+        {
+            if (_GetThermalInfo(path, out var output) == DdbResult.Success)
+            {
+                var json = MarshalAndFreeUtf8(output);
+                if (string.IsNullOrWhiteSpace(json))
+                    throw new DdbException("Unable to get thermal info");
+                return json;
+            }
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            throw new DdbException($"Error in calling ddb lib: incompatible versions ({ex.Message})", ex);
+        }
+        catch (DdbException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DdbException(
+                $"Error in calling ddb lib. Last error: \"{SafeGetLastError("get thermal info")}\", check inner exception for details", ex);
+        }
+
+        throw new DdbException(SafeGetLastError("get thermal info"));
+    }
+
+    [DllImport("ddb", EntryPoint = "DDBGetThermalPoint")]
+    private static extern DdbResult _GetThermalPoint(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string path, int x, int y, out IntPtr output);
+
+    public string GetThermalPoint(string path, int x, int y)
+    {
+        if (path == null) throw new ArgumentException("path is null");
+
+        try
+        {
+            if (_GetThermalPoint(path, x, y, out var output) == DdbResult.Success)
+            {
+                var json = MarshalAndFreeUtf8(output);
+                if (string.IsNullOrWhiteSpace(json))
+                    throw new DdbException("Unable to get thermal point");
+                return json;
+            }
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            throw new DdbException($"Error in calling ddb lib: incompatible versions ({ex.Message})", ex);
+        }
+        catch (DdbException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DdbException(
+                $"Error in calling ddb lib. Last error: \"{SafeGetLastError("get thermal point")}\", check inner exception for details", ex);
+        }
+
+        throw new DdbException(SafeGetLastError("get thermal point"));
+    }
+
+    [DllImport("ddb", EntryPoint = "DDBGetThermalAreaStats")]
+    private static extern DdbResult _GetThermalAreaStats(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string path, int x0, int y0, int x1, int y1, out IntPtr output);
+
+    public string GetThermalAreaStats(string path, int x0, int y0, int x1, int y1)
+    {
+        if (path == null) throw new ArgumentException("path is null");
+
+        try
+        {
+            if (_GetThermalAreaStats(path, x0, y0, x1, y1, out var output) == DdbResult.Success)
+            {
+                var json = MarshalAndFreeUtf8(output);
+                if (string.IsNullOrWhiteSpace(json))
+                    throw new DdbException("Unable to get thermal area stats");
+                return json;
+            }
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            throw new DdbException($"Error in calling ddb lib: incompatible versions ({ex.Message})", ex);
+        }
+        catch (DdbException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DdbException(
+                $"Error in calling ddb lib. Last error: \"{SafeGetLastError("get thermal area stats")}\", check inner exception for details", ex);
+        }
+
+        throw new DdbException(SafeGetLastError("get thermal area stats"));
+    }
+
+    #endregion
 }

--- a/Registry.Adapters/DroneDB/NativeDdbWrapper.cs
+++ b/Registry.Adapters/DroneDB/NativeDdbWrapper.cs
@@ -1331,4 +1331,283 @@ public class NativeDdbWrapper : IDdbWrapper
 
         throw new DdbException(SafeGetLastError("rescan"));
     }
+
+    #region Multispectral P/Invoke
+
+    [DllImport("ddb", EntryPoint = "DDBGetRasterInfo")]
+    private static extern DdbResult _GetRasterInfo(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string path, out IntPtr output);
+
+    public string GetRasterInfo(string path)
+    {
+        if (path == null) throw new ArgumentException("path is null");
+
+        try
+        {
+            if (_GetRasterInfo(path, out var output) == DdbResult.Success)
+            {
+                var json = MarshalAndFreeUtf8(output);
+                if (string.IsNullOrWhiteSpace(json))
+                    throw new DdbException("Unable to get raster info");
+                return json;
+            }
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            throw new DdbException($"Error in calling ddb lib: incompatible versions ({ex.Message})", ex);
+        }
+        catch (DdbException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DdbException(
+                $"Error in calling ddb lib. Last error: \"{SafeGetLastError("get raster info")}\", check inner exception for details", ex);
+        }
+
+        throw new DdbException(SafeGetLastError("get raster info"));
+    }
+
+    [DllImport("ddb", EntryPoint = "DDBGetRasterMetadata")]
+    private static extern DdbResult _GetRasterMetadata(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string path,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? formula,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? bandFilter,
+        out IntPtr output);
+
+    public string GetRasterMetadata(string path, string? formula = null, string? bandFilter = null)
+    {
+        if (path == null) throw new ArgumentException("path is null");
+
+        try
+        {
+            if (_GetRasterMetadata(path, formula, bandFilter, out var output) == DdbResult.Success)
+            {
+                var json = MarshalAndFreeUtf8(output);
+                if (string.IsNullOrWhiteSpace(json))
+                    throw new DdbException("Unable to get raster metadata");
+                return json;
+            }
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            throw new DdbException($"Error in calling ddb lib: incompatible versions ({ex.Message})", ex);
+        }
+        catch (DdbException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DdbException(
+                $"Error in calling ddb lib. Last error: \"{SafeGetLastError("get raster metadata")}\", check inner exception for details", ex);
+        }
+
+        throw new DdbException(SafeGetLastError("get raster metadata"));
+    }
+
+    [DllImport("ddb", EntryPoint = "DDBGenerateMemoryThumbnailEx")]
+    private static extern DdbResult _GenerateMemoryThumbnailEx(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string filePath, int size,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? preset,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? bands,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? formula,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? bandFilter,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? colormap,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? rescale,
+        out IntPtr outBuffer, out int outBufferSize);
+
+    public byte[] GenerateThumbnailEx(string filePath, int size, string? preset = null,
+        string? bands = null, string? formula = null, string? bandFilter = null,
+        string? colormap = null, string? rescale = null)
+    {
+        if (filePath == null) throw new ArgumentException("filePath is null");
+        if (size <= 0) throw new ArgumentException("size must be positive");
+
+        if (!File.Exists(filePath))
+            throw new DdbException($"File not found: '{filePath}'. Cannot generate thumbnail for non-existent file.");
+
+        try
+        {
+            if (_GenerateMemoryThumbnailEx(filePath, size, preset, bands, formula, bandFilter,
+                    colormap, rescale, out var outBuffer, out var outBufferSize) == DdbResult.Success)
+            {
+                var destBuf = new byte[outBufferSize];
+                Marshal.Copy(outBuffer, destBuf, 0, outBufferSize);
+                _DDBVSIFree(outBuffer);
+                return destBuf;
+            }
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            throw new DdbException($"Error in calling ddb lib: incompatible versions ({ex.Message})", ex);
+        }
+        catch (DdbException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DdbException(
+                $"Error in calling ddb lib. Last error: \"{SafeGetLastError("generate memory thumbnail ex")}\", check inner exception for details", ex);
+        }
+
+        throw new DdbException($"{SafeGetLastError("generate memory thumbnail ex")} (file: '{filePath}', size: {size})");
+    }
+
+    [DllImport("ddb", EntryPoint = "DDBMemoryTileEx")]
+    private static extern DdbResult _GenerateMemoryTileEx(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string inputPath,
+        int tz, int tx, int ty,
+        int tileSize, bool tms, bool forceRecreate,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string inputPathHash,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? preset,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? bands,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? formula,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? bandFilter,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? colormap,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? rescale,
+        out IntPtr outBuffer, out int outBufferSize);
+
+    public byte[] GenerateMemoryTileEx(string inputPath, int tz, int tx, int ty,
+        int tileSize, bool tms, bool forceRecreate, string inputPathHash,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null)
+    {
+        if (inputPath == null) throw new ArgumentException("inputPath is null");
+
+        try
+        {
+            if (_GenerateMemoryTileEx(inputPath, tz, tx, ty, tileSize, tms, forceRecreate,
+                    inputPathHash, preset, bands, formula, bandFilter, colormap, rescale,
+                    out var outBuffer, out var outBufferSize) == DdbResult.Success)
+            {
+                var destBuf = new byte[outBufferSize];
+                Marshal.Copy(outBuffer, destBuf, 0, outBufferSize);
+                _DDBVSIFree(outBuffer);
+                return destBuf;
+            }
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            throw new DdbException($"Error in calling ddb lib: incompatible versions ({ex.Message})", ex);
+        }
+        catch (DdbException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DdbException(
+                $"Error in calling ddb lib. Last error: \"{SafeGetLastError("generate memory tile ex")}\", check inner exception for details", ex);
+        }
+
+        throw new DdbException(SafeGetLastError("generate memory tile ex"));
+    }
+
+    [DllImport("ddb", EntryPoint = "DDBValidateMergeMultispectral")]
+    private static extern DdbResult _ValidateMergeMultispectral(
+        IntPtr[] paths, int numPaths, out IntPtr output);
+
+    public string ValidateMergeMultispectral(string[] paths)
+    {
+        if (paths == null || paths.Length == 0)
+            throw new ArgumentException("paths is null or empty");
+
+        var utf8Ptrs = MarshalStringArrayToUtf8(paths);
+        try
+        {
+            if (_ValidateMergeMultispectral(utf8Ptrs, paths.Length, out var output) == DdbResult.Success)
+            {
+                var json = MarshalAndFreeUtf8(output);
+                if (string.IsNullOrWhiteSpace(json))
+                    throw new DdbException("Unable to validate merge multispectral");
+                return json;
+            }
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            throw new DdbException($"Error in calling ddb lib: incompatible versions ({ex.Message})", ex);
+        }
+        catch (DdbException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DdbException(
+                $"Error in calling ddb lib. Last error: \"{SafeGetLastError("validate merge multispectral")}\", check inner exception for details", ex);
+        }
+        finally
+        {
+            FreeUtf8StringArray(utf8Ptrs);
+        }
+
+        throw new DdbException(SafeGetLastError("validate merge multispectral"));
+    }
+
+    [DllImport("ddb", EntryPoint = "DDBPreviewMergeMultispectral")]
+    private static extern DdbResult _PreviewMergeMultispectral(
+        IntPtr[] paths, int numPaths,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? previewBands,
+        int thumbSize,
+        out IntPtr outBuffer, out int outBufferSize);
+
+    public byte[] PreviewMergeMultispectral(string[] paths, string? previewBands = null, int thumbSize = 512)
+    {
+        if (paths == null || paths.Length == 0)
+            throw new ArgumentException("paths is null or empty");
+
+        var utf8Ptrs = MarshalStringArrayToUtf8(paths);
+        try
+        {
+            if (_PreviewMergeMultispectral(utf8Ptrs, paths.Length, previewBands, thumbSize,
+                    out var outBuffer, out var outBufferSize) == DdbResult.Success)
+            {
+                var destBuf = new byte[outBufferSize];
+                Marshal.Copy(outBuffer, destBuf, 0, outBufferSize);
+                _DDBVSIFree(outBuffer);
+                return destBuf;
+            }
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            throw new DdbException($"Error in calling ddb lib: incompatible versions ({ex.Message})", ex);
+        }
+        catch (DdbException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DdbException(
+                $"Error in calling ddb lib. Last error: \"{SafeGetLastError("preview merge multispectral")}\", check inner exception for details", ex);
+        }
+        finally
+        {
+            FreeUtf8StringArray(utf8Ptrs);
+        }
+
+        throw new DdbException(SafeGetLastError("preview merge multispectral"));
+    }
+
+    [DllImport("ddb", EntryPoint = "DDBMergeMultispectral")]
+    private static extern DdbResult _MergeMultispectral(
+        IntPtr[] paths, int numPaths,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string outputCog);
+
+    public void MergeMultispectral(string[] paths, string outputCog)
+    {
+        if (paths == null || paths.Length == 0)
+            throw new ArgumentException("paths is null or empty");
+        if (string.IsNullOrWhiteSpace(outputCog))
+            throw new ArgumentException("outputCog is null or empty");
+
+        var utf8Ptrs = MarshalStringArrayToUtf8(paths);
+        try
+        {
+            if (_MergeMultispectral(utf8Ptrs, paths.Length, outputCog) == DdbResult.Success) return;
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            throw new DdbException($"Error in calling ddb lib: incompatible versions ({ex.Message})", ex);
+        }
+        catch (DdbException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DdbException(
+                $"Error in calling ddb lib. Last error: \"{SafeGetLastError("merge multispectral")}\", check inner exception for details", ex);
+        }
+        finally
+        {
+            FreeUtf8StringArray(utf8Ptrs);
+        }
+
+        throw new DdbException(SafeGetLastError("merge multispectral"));
+    }
+
+    #endregion
 }

--- a/Registry.Adapters/DroneDB/NativeDdbWrapper.cs
+++ b/Registry.Adapters/DroneDB/NativeDdbWrapper.cs
@@ -138,6 +138,7 @@ public class NativeDdbWrapper : IDdbWrapper
 
     public List<Entry> Add(string ddbPath, string[] paths, bool recursive = false)
     {
+        paths = paths.Select(p => p?.Replace('\\', '/')).ToArray();
         var utf8Ptrs = MarshalStringArrayToUtf8(paths);
         try
         {
@@ -190,6 +191,7 @@ public class NativeDdbWrapper : IDdbWrapper
 
     public void Remove(string ddbPath, string[] paths)
     {
+        paths = paths.Select(p => p?.Replace('\\', '/')).ToArray();
         var utf8Ptrs = MarshalStringArrayToUtf8(paths);
         try
         {
@@ -867,6 +869,8 @@ public class NativeDdbWrapper : IDdbWrapper
 
     public void MoveEntry(string ddbPath, string source, string dest)
     {
+        source = source.Replace('\\', '/');
+        dest = dest.Replace('\\', '/');
         try
         {
             if (_MoveEntry(ddbPath, source, dest) == DdbResult.Success) return;
@@ -893,6 +897,8 @@ public class NativeDdbWrapper : IDdbWrapper
     public void Build(string ddbPath, string? source = null, string? dest = null, bool force = false,
         bool pendingOnly = false)
     {
+        source = source?.Replace('\\', '/');
+        dest = dest?.Replace('\\', '/');
         try
         {
             if (_Build(ddbPath, source, dest, force, pendingOnly) != DdbResult.Exception) return;
@@ -917,6 +923,7 @@ public class NativeDdbWrapper : IDdbWrapper
 
     public bool IsBuildable(string ddbPath, string path)
     {
+        path = path.Replace('\\', '/');
         try
         {
             if (_IsBuildable(ddbPath, path, out var isBuildable) ==
@@ -942,6 +949,7 @@ public class NativeDdbWrapper : IDdbWrapper
 
     public bool IsBuildActive(string ddbPath, string path)
     {
+        path = path.Replace('\\', '/');
         try
         {
             if (_IsBuildActive(ddbPath, path, out var isBuildActive) ==
@@ -1747,6 +1755,38 @@ public class NativeDdbWrapper : IDdbWrapper
         }
 
         throw new DdbException(SafeGetLastError("get thermal area stats"));
+    }
+
+    [DllImport("ddb", EntryPoint = "DDBMaskBorders")]
+    private static extern DdbResult _MaskBorders(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string input,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string output,
+        int nearDist,
+        [MarshalAs(UnmanagedType.Bool)] bool white);
+
+    public void MaskBorders(string input, string output, int nearDist = 15, bool white = false)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            throw new ArgumentException("input is null or empty");
+        if (string.IsNullOrWhiteSpace(output))
+            throw new ArgumentException("output is null or empty");
+
+        try
+        {
+            if (_MaskBorders(input, output, nearDist, white) == DdbResult.Success) return;
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            throw new DdbException($"Error in calling ddb lib: incompatible versions ({ex.Message})", ex);
+        }
+        catch (DdbException) { throw; }
+        catch (Exception ex)
+        {
+            throw new DdbException(
+                $"Error in calling ddb lib. Last error: \"{SafeGetLastError("mask borders")}\", check inner exception for details", ex);
+        }
+
+        throw new DdbException(SafeGetLastError("mask borders"));
     }
 
     #endregion

--- a/Registry.Common/CommonUtils.cs
+++ b/Registry.Common/CommonUtils.cs
@@ -247,12 +247,27 @@ public static class CommonUtils
     }
 
     /// <summary>
+    /// Validates that an array of relative paths doesn't contain path traversal attacks.
+    /// Throws ArgumentException if any path is invalid or escapes the base directory.
+    /// </summary>
+    /// <param name="paths">The array of relative paths to validate.</param>
+    /// <param name="baseDirectory">The base directory that all paths must stay within.</param>
+    /// <exception cref="ArgumentNullException">Thrown when paths is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when any path is empty, absolute, or contains traversal attempts.</exception>
+    public static void ValidateRelativePaths(string[] paths, string baseDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+
+        foreach (var path in paths)
+            ValidateRelativePath(path, baseDirectory);
+    }
+    
+    /// <summary>
     /// Validates that a relative path doesn't contain path traversal attacks.
     /// Throws ArgumentException if the path is invalid or escapes the base directory.
     /// </summary>
     /// <param name="path">The relative path to validate.</param>
     /// <param name="baseDirectory">The base directory that the path must stay within.</param>
-    /// <param name="paramName">The parameter name for the exception.</param>
     /// <exception cref="ArgumentException">Thrown when the path is empty, absolute, or contains traversal attempts.</exception>
     public static void ValidateRelativePath(string path, string baseDirectory)
     {

--- a/Registry.Common/CommonUtils.cs
+++ b/Registry.Common/CommonUtils.cs
@@ -254,24 +254,24 @@ public static class CommonUtils
     /// <param name="baseDirectory">The base directory that the path must stay within.</param>
     /// <param name="paramName">The parameter name for the exception.</param>
     /// <exception cref="ArgumentException">Thrown when the path is empty, absolute, or contains traversal attempts.</exception>
-    public static void ValidateRelativePath(string path, string baseDirectory, string paramName = "path")
+    public static void ValidateRelativePath(string path, string baseDirectory)
     {
         if (string.IsNullOrWhiteSpace(path))
-            throw new ArgumentException("Path cannot be empty.", paramName);
+            throw new ArgumentException("Path cannot be empty.", nameof(path));
 
         if (string.IsNullOrWhiteSpace(baseDirectory))
             throw new ArgumentException("Base directory cannot be empty.", nameof(baseDirectory));
 
         // Reject absolute/rooted paths (including UNC on Windows)
         if (Path.IsPathRooted(path))
-            throw new ArgumentException("Invalid path: absolute paths are not allowed.", paramName);
+            throw new ArgumentException("Invalid path: absolute paths are not allowed.", nameof(path));
 
         // Forbid '.' and '..' segments (semantic check, avoids false positives on 'file..txt')
         var segments = path.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
         foreach (var s in segments)
         {
             if (s is "." or "..")
-                throw new ArgumentException("Invalid path: path traversal is not allowed.", paramName);
+                throw new ArgumentException("Invalid path: path traversal is not allowed.", nameof(path));
         }
 
         string baseFull;
@@ -289,7 +289,7 @@ public static class CommonUtils
         }
         catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
         {
-            throw new ArgumentException("Invalid path.", paramName, ex);
+            throw new ArgumentException("Invalid path.", nameof(path), ex);
         }
 
         var comparison = OperatingSystem.IsWindows()
@@ -297,7 +297,7 @@ public static class CommonUtils
             : StringComparison.Ordinal;
 
         if (!combinedFull.StartsWith(baseFull, comparison))
-            throw new ArgumentException("Invalid path: path traversal is not allowed.", paramName);
+            throw new ArgumentException("Invalid path: path traversal is not allowed.", nameof(path));
     }
 
     public static (string, Stream) GetTempStream(int bufferSize = 104857600)

--- a/Registry.Ports/DroneDB/IDDB.cs
+++ b/Registry.Ports/DroneDB/IDDB.cs
@@ -131,6 +131,21 @@ public interface IDDB
         string? preset = null, string? bands = null, string? formula = null,
         string? bandFilter = null, string? colormap = null, string? rescale = null);
 
+    /// <summary>
+    /// Get thermal info including calibration, temperature range, and dimensions
+    /// </summary>
+    string GetThermalInfo(string path);
+
+    /// <summary>
+    /// Get temperature at a specific pixel location
+    /// </summary>
+    string GetThermalPoint(string path, int x, int y);
+
+    /// <summary>
+    /// Get temperature statistics for a rectangular area
+    /// </summary>
+    string GetThermalAreaStats(string path, int x0, int y0, int x1, int y1);
+
     // These consts are like magic strings: if anything changes this goes kaboom!
     public const string DatabaseFolderName = ".ddb";
     public const string BuildFolderName = "build";

--- a/Registry.Ports/DroneDB/IDDB.cs
+++ b/Registry.Ports/DroneDB/IDDB.cs
@@ -146,6 +146,11 @@ public interface IDDB
     /// </summary>
     string GetThermalAreaStats(string path, int x0, int y0, int x1, int y1);
 
+    /// <summary>
+    /// Mask orthophoto borders making them transparent
+    /// </summary>
+    void MaskBorders(string input, string output, int nearDist = 15, bool white = false);
+
     // These consts are like magic strings: if anything changes this goes kaboom!
     public const string DatabaseFolderName = ".ddb";
     public const string BuildFolderName = "build";

--- a/Registry.Ports/DroneDB/IDDB.cs
+++ b/Registry.Ports/DroneDB/IDDB.cs
@@ -85,6 +85,45 @@ public interface IDDB
     /// </summary>
     void ClearBuildCache();
 
+    /// <summary>
+    /// Get raster info including bands, detected sensor, and presets
+    /// </summary>
+    string GetRasterInfo(string path);
+
+    /// <summary>
+    /// Get raster statistics and histogram for a band or formula
+    /// </summary>
+    string GetRasterMetadata(string path, string? formula = null, string? bandFilter = null);
+
+    /// <summary>
+    /// Generate thumbnail with extended visualization params
+    /// </summary>
+    byte[] GenerateThumbnailEx(string imagePath, int size, string? preset = null,
+        string? bands = null, string? formula = null, string? bandFilter = null,
+        string? colormap = null, string? rescale = null);
+
+    /// <summary>
+    /// Generate tile with extended visualization params
+    /// </summary>
+    byte[] GenerateTileEx(string inputPath, int tz, int tx, int ty, bool retina, string inputPathHash,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null);
+
+    /// <summary>
+    /// Validate merge-multispectral inputs
+    /// </summary>
+    string ValidateMergeMultispectral(string[] paths);
+
+    /// <summary>
+    /// Preview merge-multispectral result
+    /// </summary>
+    byte[] PreviewMergeMultispectral(string[] paths, string? previewBands = null, int thumbSize = 512);
+
+    /// <summary>
+    /// Merge single-band rasters into multi-band COG
+    /// </summary>
+    void MergeMultispectral(string[] paths, string outputCog);
+
     // These consts are like magic strings: if anything changes this goes kaboom!
     public const string DatabaseFolderName = ".ddb";
     public const string BuildFolderName = "build";

--- a/Registry.Ports/DroneDB/IDDB.cs
+++ b/Registry.Ports/DroneDB/IDDB.cs
@@ -124,6 +124,13 @@ public interface IDDB
     /// </summary>
     void MergeMultispectral(string[] paths, string outputCog);
 
+    /// <summary>
+    /// Export raster with visualization params applied as GeoTIFF
+    /// </summary>
+    void ExportRaster(string inputPath, string outputPath,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null);
+
     // These consts are like magic strings: if anything changes this goes kaboom!
     public const string DatabaseFolderName = ".ddb";
     public const string BuildFolderName = "build";

--- a/Registry.Ports/IDdbWrapper.cs
+++ b/Registry.Ports/IDdbWrapper.cs
@@ -161,4 +161,9 @@ public interface IDdbWrapper
     /// Get temperature statistics for a rectangular area
     /// </summary>
     public string GetThermalAreaStats(string path, int x0, int y0, int x1, int y1);
+
+    /// <summary>
+    /// Mask orthophoto borders making them transparent
+    /// </summary>
+    public void MaskBorders(string input, string output, int nearDist = 15, bool white = false);
 }

--- a/Registry.Ports/IDdbWrapper.cs
+++ b/Registry.Ports/IDdbWrapper.cs
@@ -99,4 +99,44 @@ public interface IDdbWrapper
 
     string TileMimeType { get; }
     string ThumbnailMimeType { get; }
+
+    /// <summary>
+    /// Get raster info including bands, detected sensor, and presets
+    /// </summary>
+    public string GetRasterInfo(string path);
+
+    /// <summary>
+    /// Get raster statistics and histogram for a band or formula
+    /// </summary>
+    public string GetRasterMetadata(string path, string? formula = null, string? bandFilter = null);
+
+    /// <summary>
+    /// Generate thumbnail with extended visualization params
+    /// </summary>
+    public byte[] GenerateThumbnailEx(string filePath, int size, string? preset = null,
+        string? bands = null, string? formula = null, string? bandFilter = null,
+        string? colormap = null, string? rescale = null);
+
+    /// <summary>
+    /// Generate tile with extended visualization params
+    /// </summary>
+    public byte[] GenerateMemoryTileEx(string inputPath, int tz, int tx, int ty,
+        int tileSize, bool tms, bool forceRecreate, string inputPathHash,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null);
+
+    /// <summary>
+    /// Validate merge-multispectral inputs
+    /// </summary>
+    public string ValidateMergeMultispectral(string[] paths);
+
+    /// <summary>
+    /// Preview merge-multispectral result
+    /// </summary>
+    public byte[] PreviewMergeMultispectral(string[] paths, string? previewBands = null, int thumbSize = 512);
+
+    /// <summary>
+    /// Merge single-band rasters into multi-band COG
+    /// </summary>
+    public void MergeMultispectral(string[] paths, string outputCog);
 }

--- a/Registry.Ports/IDdbWrapper.cs
+++ b/Registry.Ports/IDdbWrapper.cs
@@ -139,4 +139,11 @@ public interface IDdbWrapper
     /// Merge single-band rasters into multi-band COG
     /// </summary>
     public void MergeMultispectral(string[] paths, string outputCog);
+
+    /// <summary>
+    /// Export raster with visualization params applied as GeoTIFF
+    /// </summary>
+    public void ExportRaster(string inputPath, string outputPath,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null);
 }

--- a/Registry.Ports/IDdbWrapper.cs
+++ b/Registry.Ports/IDdbWrapper.cs
@@ -146,4 +146,19 @@ public interface IDdbWrapper
     public void ExportRaster(string inputPath, string outputPath,
         string? preset = null, string? bands = null, string? formula = null,
         string? bandFilter = null, string? colormap = null, string? rescale = null);
+
+    /// <summary>
+    /// Get thermal info including calibration, temperature range, and dimensions
+    /// </summary>
+    public string GetThermalInfo(string path);
+
+    /// <summary>
+    /// Get temperature at a specific pixel location
+    /// </summary>
+    public string GetThermalPoint(string path, int x, int y);
+
+    /// <summary>
+    /// Get temperature statistics for a rectangular area
+    /// </summary>
+    public string GetThermalAreaStats(string path, int x0, int y0, int x1, int y1);
 }

--- a/Registry.Web.Test/ObjectManagerTest.cs
+++ b/Registry.Web.Test/ObjectManagerTest.cs
@@ -868,7 +868,7 @@ public class ObjectManagerTest : TestBase
 
         // Initialize destination DDB and add the file
         var destDdb = ddbManager.Get("admin", Guid.Parse("6c1f5555-d001-4411-9308-42aa6ccd7fd6"));
-        destDdb.AddRaw(destPath);
+        destDdb.AddRaw("DJI_0027.JPG");
 
         // Try to transfer with overwrite=false (should fail)
         var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await objectManager.Transfer(

--- a/Registry.Web.Test/ObjectManagerTest.cs
+++ b/Registry.Web.Test/ObjectManagerTest.cs
@@ -1426,4 +1426,160 @@ public class ObjectManagerTest : TestBase
     }
 
     #endregion
+
+    #region Raster/Thermal/Export Path Validation Tests
+
+    [Test]
+    public async Task GetRasterInfo_TraversalPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GetRasterInfo(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "../escape.tif"));
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GetRasterInfo(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "/etc/passwd"));
+    }
+
+    [Test]
+    public async Task GetRasterMetadata_TraversalPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GetRasterMetadata(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "../escape.tif"));
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GetRasterMetadata(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "/etc/passwd"));
+    }
+
+    [Test]
+    public async Task GenerateThumbnailDataEx_TraversalPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GenerateThumbnailDataEx(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "../escape.tif", 256));
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GenerateThumbnailDataEx(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "/etc/passwd", 256));
+    }
+
+    [Test]
+    public async Task GenerateTileDataEx_TraversalPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GenerateTileDataEx(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "../escape.tif", 1, 0, 0, false));
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GenerateTileDataEx(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "/etc/passwd", 1, 0, 0, false));
+    }
+
+    [Test]
+    public async Task ExportRaster_TraversalPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.ExportRaster(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "../escape.tif"));
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.ExportRaster(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "/etc/passwd"));
+    }
+
+    [Test]
+    public async Task GetThermalInfo_TraversalPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GetThermalInfo(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "../escape.tif"));
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GetThermalInfo(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "/etc/passwd"));
+    }
+
+    [Test]
+    public async Task GetThermalPoint_TraversalPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GetThermalPoint(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "../escape.tif", 0, 0));
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GetThermalPoint(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "/etc/passwd", 0, 0));
+    }
+
+    [Test]
+    public async Task GetThermalAreaStats_TraversalPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GetThermalAreaStats(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "../escape.tif", 0, 0, 10, 10));
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.GetThermalAreaStats(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "/etc/passwd", 0, 0, 10, 10));
+    }
+
+    #endregion
 }

--- a/Registry.Web.Test/ObjectManagerTest.cs
+++ b/Registry.Web.Test/ObjectManagerTest.cs
@@ -1300,4 +1300,130 @@ public class ObjectManagerTest : TestBase
     }
 
     #endregion
+
+    #region Multispectral Path Validation Tests
+
+    private ObjectsManager CreateObjectsManagerWithMockedDdb(RegistryContext context, Mock<IDDB> ddbMock)
+    {
+        var settings = JsonConvert.DeserializeObject<AppSettings>(_settingsJson);
+        _appSettingsMock.Setup(o => o.Value).Returns(settings);
+        _authManagerMock.Setup(o => o.IsUserAdmin()).Returns(Task.FromResult(true));
+        _authManagerMock.Setup(o => o.RequestAccess(It.IsAny<Dataset>(), It.IsAny<AccessType>()))
+            .Returns(Task.FromResult(true));
+
+        _ddbFactoryMock.Setup(x => x.Get(It.IsAny<string>(), It.IsAny<Guid>())).Returns(ddbMock.Object);
+
+        var webUtils = new WebUtils(_authManagerMock.Object, context, _appSettingsMock.Object,
+            _httpContextAccessorMock.Object, _ddbFactoryMock.Object);
+
+        return new ObjectsManager(_objectManagerLogger, context, _appSettingsMock.Object,
+            _ddbFactoryMock.Object, webUtils, _authManagerMock.Object,
+            _cacheManager, _fileSystem, _backgroundJobsProcessor, DdbWrapper,
+            _thumbnailGeneratorMock.Object, _jobIndexQueryMock.Object, _buildPendingService);
+    }
+
+    [Test]
+    public async Task ValidateMergeMultispectral_TraversalPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        // Absolute path
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.ValidateMergeMultispectral(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, new[] { "/etc/passwd" }));
+
+        // Traversal path
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.ValidateMergeMultispectral(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, new[] { "../secret.tif" }));
+
+        // Mixed valid + traversal
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.ValidateMergeMultispectral(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, new[] { "band1.tif", "../../escape.tif" }));
+    }
+
+    [Test]
+    public async Task PreviewMergeMultispectral_TraversalPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.PreviewMergeMultispectral(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, new[] { "../escape.tif" }));
+    }
+
+    [Test]
+    public async Task MergeMultispectral_TraversalInputPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        // Traversal in input paths
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.MergeMultispectral(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, new[] { "../escape.tif" }, "output.tif"));
+    }
+
+    [Test]
+    public async Task MergeMultispectral_TraversalOutputPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        // Traversal in output path
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.MergeMultispectral(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, new[] { "band1.tif" }, "../escape.tif"));
+    }
+
+    [Test]
+    public async Task MergeMultispectral_AbsoluteOutputPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.MergeMultispectral(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, new[] { "band1.tif" }, "/tmp/output.tif"));
+    }
+
+    [Test]
+    public async Task CheckMaskedFileExists_TraversalPath_ThrowsArgumentException()
+    {
+        await using var context = GetTest1Context();
+
+        var ddbMock = new Mock<IDDB>();
+        ddbMock.Setup(x => x.DatasetFolderPath).Returns(Path.Combine(Path.GetTempPath(), "test-dataset"));
+
+        var objectManager = CreateObjectsManagerWithMockedDdb(context, ddbMock);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await objectManager.CheckMaskedFileExists(MagicStrings.PublicOrganizationSlug,
+                MagicStrings.DefaultDatasetSlug, "../escape.tif"));
+    }
+
+    #endregion
 }

--- a/Registry.Web/Controllers/ObjectsController.cs
+++ b/Registry.Web/Controllers/ObjectsController.cs
@@ -1082,5 +1082,81 @@ public class ObjectsController : ControllerBaseEx
 
     #endregion
 
+    #region Thermal
+
+    /// <summary>Get thermal info including calibration, temperature range, and dimensions.</summary>
+    [HttpGet("thermal-info", Name = nameof(ObjectsController) + "." + nameof(GetThermalInfo))]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetThermalInfo(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromQuery, Required] string path)
+    {
+        try
+        {
+            var json = await _objectsManager.GetThermalInfo(orgSlug, dsSlug, path);
+            return Content(json, "application/json");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in GetThermalInfo('{OrgSlug}', '{DsSlug}', '{Path}')", orgSlug, dsSlug, path);
+            return ExceptionResult(ex);
+        }
+    }
+
+    /// <summary>Get temperature at a specific pixel location.</summary>
+    [HttpGet("thermal-point", Name = nameof(ObjectsController) + "." + nameof(GetThermalPoint))]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetThermalPoint(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromQuery, Required] string path,
+        [FromQuery, Required] int x,
+        [FromQuery, Required] int y)
+    {
+        try
+        {
+            var json = await _objectsManager.GetThermalPoint(orgSlug, dsSlug, path, x, y);
+            return Content(json, "application/json");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in GetThermalPoint('{OrgSlug}', '{DsSlug}', '{Path}')", orgSlug, dsSlug, path);
+            return ExceptionResult(ex);
+        }
+    }
+
+    /// <summary>Get temperature statistics for a rectangular area.</summary>
+    [HttpGet("thermal-area-stats", Name = nameof(ObjectsController) + "." + nameof(GetThermalAreaStats))]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetThermalAreaStats(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromQuery, Required] string path,
+        [FromQuery, Required] int x0,
+        [FromQuery, Required] int y0,
+        [FromQuery, Required] int x1,
+        [FromQuery, Required] int y1)
+    {
+        try
+        {
+            var json = await _objectsManager.GetThermalAreaStats(orgSlug, dsSlug, path, x0, y0, x1, y1);
+            return Content(json, "application/json");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in GetThermalAreaStats('{OrgSlug}', '{DsSlug}', '{Path}')", orgSlug, dsSlug, path);
+            return ExceptionResult(ex);
+        }
+    }
+
+    #endregion
+
 
 }

--- a/Registry.Web/Controllers/ObjectsController.cs
+++ b/Registry.Web/Controllers/ObjectsController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1063,8 +1064,14 @@ public class ObjectsController : ControllerBaseEx
             if (string.IsNullOrWhiteSpace(request.OutputPath))
                 return BadRequest(new ErrorResponse("outputPath is required"));
 
+            // Early path traversal check at controller level
+            if (Path.IsPathRooted(request.OutputPath) ||
+                request.OutputPath.Contains("..") ||
+                request.OutputPath.Contains('\\'))
+                return BadRequest(new ErrorResponse("Invalid output path"));
+
             await _objectsManager.MergeMultispectral(orgSlug, dsSlug, request.Paths, request.OutputPath);
-            return Ok(new { message = "Merge completed successfully" });
+            return Ok(new { ok = true });
         }
         catch (Exception ex)
         {

--- a/Registry.Web/Controllers/ObjectsController.cs
+++ b/Registry.Web/Controllers/ObjectsController.cs
@@ -893,6 +893,9 @@ public class ObjectsController : ControllerBaseEx
     {
         try
         {
+            var pathError = ValidatePath(path);
+            if (pathError != null) return pathError;
+
             var json = await _objectsManager.GetRasterInfo(orgSlug, dsSlug, path);
             return Content(json, "application/json");
         }
@@ -917,6 +920,9 @@ public class ObjectsController : ControllerBaseEx
     {
         try
         {
+            var pathError = ValidatePath(path);
+            if (pathError != null) return pathError;
+
             var json = await _objectsManager.GetRasterMetadata(orgSlug, dsSlug, path, formula, bandFilter);
             return Content(json, "application/json");
         }
@@ -946,6 +952,9 @@ public class ObjectsController : ControllerBaseEx
     {
         try
         {
+            var pathError = ValidatePath(path);
+            if (pathError != null) return pathError;
+
             var res = await _objectsManager.GenerateThumbnailDataEx(orgSlug, dsSlug, path, size,
                 preset, bands, formula, bandFilter, colormap, rescale);
 
@@ -981,6 +990,9 @@ public class ObjectsController : ControllerBaseEx
     {
         try
         {
+            var pathError = ValidatePath(path);
+            if (pathError != null) return pathError;
+
             var retina = tyRaw.EndsWith("@2x");
             if (!int.TryParse(retina ? tyRaw.Replace("@2x", string.Empty) : tyRaw, out var ty))
                 throw new ArgumentException("Invalid input parameters (retina indicator should be '@2x')");
@@ -1015,6 +1027,9 @@ public class ObjectsController : ControllerBaseEx
     {
         try
         {
+            var pathError = ValidatePath(path);
+            if (pathError != null) return pathError;
+
             var res = await _objectsManager.ExportRaster(orgSlug, dsSlug, path,
                 preset, bands, formula, bandFilter, colormap, rescale);
 
@@ -1119,6 +1134,9 @@ public class ObjectsController : ControllerBaseEx
     {
         try
         {
+            var pathError = ValidatePath(path);
+            if (pathError != null) return pathError;
+
             var json = await _objectsManager.GetThermalInfo(orgSlug, dsSlug, path);
             return Content(json, "application/json");
         }
@@ -1143,6 +1161,9 @@ public class ObjectsController : ControllerBaseEx
     {
         try
         {
+            var pathError = ValidatePath(path);
+            if (pathError != null) return pathError;
+
             var json = await _objectsManager.GetThermalPoint(orgSlug, dsSlug, path, x, y);
             return Content(json, "application/json");
         }
@@ -1169,6 +1190,9 @@ public class ObjectsController : ControllerBaseEx
     {
         try
         {
+            var pathError = ValidatePath(path);
+            if (pathError != null) return pathError;
+
             var json = await _objectsManager.GetThermalAreaStats(orgSlug, dsSlug, path, x0, y0, x1, y1);
             return Content(json, "application/json");
         }

--- a/Registry.Web/Controllers/ObjectsController.cs
+++ b/Registry.Web/Controllers/ObjectsController.cs
@@ -1158,5 +1158,65 @@ public class ObjectsController : ControllerBaseEx
 
     #endregion
 
+    #region MaskBorders
+
+    /// <summary>Check if a masked version of the file already exists.</summary>
+    [HttpPost("mask-borders/check", Name = nameof(ObjectsController) + "." + nameof(CheckMaskBorders))]
+    [ProducesResponseType(typeof(MaskBordersCheckResponseDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CheckMaskBorders(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromBody, Required] MaskBordersRequestDto request)
+    {
+        try
+        {
+            _logger.LogDebug("Objects controller CheckMaskBorders('{OrgSlug}', '{DsSlug}', '{Path}')",
+                orgSlug, dsSlug, request.Path);
+
+            var result = await _objectsManager.CheckMaskedFileExists(orgSlug, dsSlug, request.Path);
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in CheckMaskBorders('{OrgSlug}', '{DsSlug}', '{Path}')",
+                orgSlug, dsSlug, request.Path);
+            return ExceptionResult(ex);
+        }
+    }
+
+    /// <summary>Start masking orthophoto borders to make them transparent.</summary>
+    [HttpPost("mask-borders", Name = nameof(ObjectsController) + "." + nameof(MaskBorders))]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> MaskBorders(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromBody, Required] MaskBordersRequestDto request)
+    {
+        try
+        {
+            _logger.LogDebug("Objects controller MaskBorders('{OrgSlug}', '{DsSlug}', '{Path}')",
+                orgSlug, dsSlug, request.Path);
+
+            // Early path traversal check
+            if (Path.IsPathRooted(request.Path) ||
+                request.Path.Contains("..") ||
+                request.Path.Contains('\\'))
+                return BadRequest(new ErrorResponse("Invalid path"));
+
+            await _objectsManager.MaskBorders(orgSlug, dsSlug, request.Path, request.Near, request.White);
+            return Ok(new { ok = true });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in MaskBorders('{OrgSlug}', '{DsSlug}', '{Path}')",
+                orgSlug, dsSlug, request.Path);
+            return ExceptionResult(ex);
+        }
+    }
+
+    #endregion
+
 
 }

--- a/Registry.Web/Controllers/ObjectsController.cs
+++ b/Registry.Web/Controllers/ObjectsController.cs
@@ -975,6 +975,37 @@ public class ObjectsController : ControllerBaseEx
         }
     }
 
+    /// <summary>Export raster with visualization params applied as GeoTIFF.</summary>
+    [HttpGet("export", Name = nameof(ObjectsController) + "." + nameof(ExportRaster))]
+    [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> ExportRaster(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromQuery, Required] string path,
+        [FromQuery] string? format = "geotiff",
+        [FromQuery] string? preset = null,
+        [FromQuery] string? bands = null,
+        [FromQuery] string? formula = null,
+        [FromQuery] string? bandFilter = null,
+        [FromQuery] string? colormap = null,
+        [FromQuery] string? rescale = null)
+    {
+        try
+        {
+            var res = await _objectsManager.ExportRaster(orgSlug, dsSlug, path,
+                preset, bands, formula, bandFilter, colormap, rescale);
+
+            return File(res.Data, res.ContentType, res.Name);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in ExportRaster('{OrgSlug}', '{DsSlug}', '{Path}')", orgSlug, dsSlug, path);
+            return ExceptionResult(ex);
+        }
+    }
+
     /// <summary>Validate merge-multispectral inputs.</summary>
     [HttpPost("merge-multispectral/validate", Name = nameof(ObjectsController) + "." + nameof(ValidateMergeMultispectral))]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/Registry.Web/Controllers/ObjectsController.cs
+++ b/Registry.Web/Controllers/ObjectsController.cs
@@ -857,5 +857,192 @@ public class ObjectsController : ControllerBaseEx
         }
     }
 
+    #region Multispectral
+
+    /// <summary>Get raster info (bands, sensor profile, presets) for a file.</summary>
+    [HttpGet("raster-info", Name = nameof(ObjectsController) + "." + nameof(GetRasterInfo))]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetRasterInfo(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromQuery, Required] string path)
+    {
+        try
+        {
+            var json = await _objectsManager.GetRasterInfo(orgSlug, dsSlug, path);
+            return Content(json, "application/json");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in GetRasterInfo('{OrgSlug}', '{DsSlug}', '{Path}')", orgSlug, dsSlug, path);
+            return ExceptionResult(ex);
+        }
+    }
+
+    /// <summary>Get raster statistics/histogram for a band or formula.</summary>
+    [HttpGet("raster-metadata", Name = nameof(ObjectsController) + "." + nameof(GetRasterMetadata))]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetRasterMetadata(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromQuery, Required] string path,
+        [FromQuery] string? formula,
+        [FromQuery] string? bandFilter)
+    {
+        try
+        {
+            var json = await _objectsManager.GetRasterMetadata(orgSlug, dsSlug, path, formula, bandFilter);
+            return Content(json, "application/json");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in GetRasterMetadata('{OrgSlug}', '{DsSlug}', '{Path}')", orgSlug, dsSlug, path);
+            return ExceptionResult(ex);
+        }
+    }
+
+    /// <summary>Generate thumbnail with extended visualization params.</summary>
+    [HttpGet("thumb-ex", Name = nameof(ObjectsController) + "." + nameof(GenerateThumbnailEx))]
+    [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GenerateThumbnailEx(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromQuery, Required] string path,
+        [FromQuery] int? size,
+        [FromQuery] string? preset,
+        [FromQuery] string? bands,
+        [FromQuery] string? formula,
+        [FromQuery] string? bandFilter,
+        [FromQuery] string? colormap,
+        [FromQuery] string? rescale)
+    {
+        try
+        {
+            var res = await _objectsManager.GenerateThumbnailDataEx(orgSlug, dsSlug, path, size,
+                preset, bands, formula, bandFilter, colormap, rescale);
+
+            if (res == null) return NotFound();
+            return File(res.Data, res.ContentType, res.Name);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in GenerateThumbnailEx('{OrgSlug}', '{DsSlug}', '{Path}')", orgSlug, dsSlug, path);
+            return ExceptionResult(new Exception("Cannot generate thumbnail"));
+        }
+    }
+
+    /// <summary>Generate tile with extended visualization params.</summary>
+    [HttpGet("tiles-ex/{tz:int}/{tx:int}/{tyRaw}.{ext:regex(^(png|webp)$)}", Name = nameof(ObjectsController) + "." + nameof(GenerateTileEx))]
+    [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GenerateTileEx(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromRoute, Required] int tz,
+        [FromRoute, Required] int tx,
+        [FromRoute, Required] string tyRaw,
+        [FromQuery, Required] string path,
+        [FromRoute, Required] string ext,
+        [FromQuery] string? preset,
+        [FromQuery] string? bands,
+        [FromQuery] string? formula,
+        [FromQuery] string? bandFilter,
+        [FromQuery] string? colormap,
+        [FromQuery] string? rescale)
+    {
+        try
+        {
+            var retina = tyRaw.EndsWith("@2x");
+            if (!int.TryParse(retina ? tyRaw.Replace("@2x", string.Empty) : tyRaw, out var ty))
+                throw new ArgumentException("Invalid input parameters (retina indicator should be '@2x')");
+
+            var res = await _objectsManager.GenerateTileDataEx(orgSlug, dsSlug, path, tz, tx, ty, retina,
+                preset, bands, formula, bandFilter, colormap, rescale);
+
+            return File(res.Data, res.ContentType, res.Name);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in GenerateTileEx('{OrgSlug}', '{DsSlug}', '{Path}')", orgSlug, dsSlug, path);
+            return ExceptionResult(ex);
+        }
+    }
+
+    /// <summary>Validate merge-multispectral inputs.</summary>
+    [HttpPost("merge-multispectral/validate", Name = nameof(ObjectsController) + "." + nameof(ValidateMergeMultispectral))]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ValidateMergeMultispectral(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromBody, Required] MergeMultispectralRequestDto request)
+    {
+        try
+        {
+            var json = await _objectsManager.ValidateMergeMultispectral(orgSlug, dsSlug, request.Paths);
+            return Content(json, "application/json");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in ValidateMergeMultispectral('{OrgSlug}', '{DsSlug}')", orgSlug, dsSlug);
+            return ExceptionResult(ex);
+        }
+    }
+
+    /// <summary>Preview merge-multispectral result.</summary>
+    [HttpPost("merge-multispectral/preview", Name = nameof(ObjectsController) + "." + nameof(PreviewMergeMultispectral))]
+    [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> PreviewMergeMultispectral(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromBody, Required] MergeMultispectralRequestDto request)
+    {
+        try
+        {
+            var data = await _objectsManager.PreviewMergeMultispectral(orgSlug, dsSlug, request.Paths,
+                request.PreviewBands, request.ThumbSize ?? 512);
+            return File(data, "image/webp", "preview.webp");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in PreviewMergeMultispectral('{OrgSlug}', '{DsSlug}')", orgSlug, dsSlug);
+            return ExceptionResult(ex);
+        }
+    }
+
+    /// <summary>Merge single-band rasters into a multi-band COG.</summary>
+    [HttpPost("merge-multispectral", Name = nameof(ObjectsController) + "." + nameof(MergeMultispectral))]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> MergeMultispectral(
+        [FromRoute, Required] string orgSlug,
+        [FromRoute, Required] string dsSlug,
+        [FromBody, Required] MergeMultispectralRequestDto request)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(request.OutputPath))
+                return BadRequest(new ErrorResponse("outputPath is required"));
+
+            await _objectsManager.MergeMultispectral(orgSlug, dsSlug, request.Paths, request.OutputPath);
+            return Ok(new { message = "Merge completed successfully" });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in MergeMultispectral('{OrgSlug}', '{DsSlug}')", orgSlug, dsSlug);
+            return ExceptionResult(ex);
+        }
+    }
+
+    #endregion
+
 
 }

--- a/Registry.Web/Controllers/ObjectsController.cs
+++ b/Registry.Web/Controllers/ObjectsController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -38,6 +39,26 @@ public class ObjectsController : ControllerBaseEx
     {
         _objectsManager = datasetsManager;
         _logger = logger;
+    }
+
+    private static bool IsTraversalPath(string path) =>
+        string.IsNullOrWhiteSpace(path) ||
+        Path.IsPathRooted(path) ||
+        path.Split('/', '\\').Any(s => s is "." or "..");
+
+    private IActionResult? ValidatePath(string path) =>
+        IsTraversalPath(path) ? BadRequest(new ErrorResponse("Invalid path")) : null;
+
+    private IActionResult? ValidatePaths(IReadOnlyCollection<string>? paths, string? outputPath = null)
+    {
+        if (paths == null || paths.Count == 0)
+            return BadRequest(new ErrorResponse("paths is required"));
+        foreach (var p in paths)
+            if (IsTraversalPath(p))
+                return BadRequest(new ErrorResponse("Invalid input path"));
+        if (outputPath != null && IsTraversalPath(outputPath))
+            return BadRequest(new ErrorResponse("Invalid output path"));
+        return null;
     }
 
     /// <summary>
@@ -985,7 +1006,6 @@ public class ObjectsController : ControllerBaseEx
         [FromRoute, Required] string orgSlug,
         [FromRoute, Required] string dsSlug,
         [FromQuery, Required] string path,
-        [FromQuery] string? format = "geotiff",
         [FromQuery] string? preset = null,
         [FromQuery] string? bands = null,
         [FromQuery] string? formula = null,
@@ -1018,6 +1038,9 @@ public class ObjectsController : ControllerBaseEx
     {
         try
         {
+            var validationError = ValidatePaths(request.Paths);
+            if (validationError != null) return validationError;
+
             var json = await _objectsManager.ValidateMergeMultispectral(orgSlug, dsSlug, request.Paths);
             return Content(json, "application/json");
         }
@@ -1039,6 +1062,9 @@ public class ObjectsController : ControllerBaseEx
     {
         try
         {
+            var validationError = ValidatePaths(request.Paths);
+            if (validationError != null) return validationError;
+
             var data = await _objectsManager.PreviewMergeMultispectral(orgSlug, dsSlug, request.Paths,
                 request.PreviewBands, request.ThumbSize ?? 512);
             return File(data, "image/webp", "preview.webp");
@@ -1064,11 +1090,8 @@ public class ObjectsController : ControllerBaseEx
             if (string.IsNullOrWhiteSpace(request.OutputPath))
                 return BadRequest(new ErrorResponse("outputPath is required"));
 
-            // Early path traversal check at controller level
-            if (Path.IsPathRooted(request.OutputPath) ||
-                request.OutputPath.Contains("..") ||
-                request.OutputPath.Contains('\\'))
-                return BadRequest(new ErrorResponse("Invalid output path"));
+            var validationError = ValidatePaths(request.Paths, request.OutputPath);
+            if (validationError != null) return validationError;
 
             await _objectsManager.MergeMultispectral(orgSlug, dsSlug, request.Paths, request.OutputPath);
             return Ok(new { ok = true });
@@ -1174,6 +1197,9 @@ public class ObjectsController : ControllerBaseEx
             _logger.LogDebug("Objects controller CheckMaskBorders('{OrgSlug}', '{DsSlug}', '{Path}')",
                 orgSlug, dsSlug, request.Path);
 
+            var pathError = ValidatePath(request.Path);
+            if (pathError != null) return pathError;
+
             var result = await _objectsManager.CheckMaskedFileExists(orgSlug, dsSlug, request.Path);
             return Ok(result);
         }
@@ -1200,10 +1226,8 @@ public class ObjectsController : ControllerBaseEx
                 orgSlug, dsSlug, request.Path);
 
             // Early path traversal check
-            if (Path.IsPathRooted(request.Path) ||
-                request.Path.Contains("..") ||
-                request.Path.Contains('\\'))
-                return BadRequest(new ErrorResponse("Invalid path"));
+            var pathError = ValidatePath(request.Path);
+            if (pathError != null) return pathError;
 
             await _objectsManager.MaskBorders(orgSlug, dsSlug, request.Path, request.Near, request.White);
             return Ok(new { ok = true });

--- a/Registry.Web/Models/DTO/MaskBordersDto.cs
+++ b/Registry.Web/Models/DTO/MaskBordersDto.cs
@@ -1,0 +1,18 @@
+#nullable enable
+using System.ComponentModel.DataAnnotations;
+
+namespace Registry.Web.Models.DTO;
+
+public class MaskBordersRequestDto
+{
+    [Required]
+    public string Path { get; set; } = null!;
+    public int Near { get; set; } = 15;
+    public bool White { get; set; } = false;
+}
+
+public class MaskBordersCheckResponseDto
+{
+    public bool Exists { get; set; }
+    public string OutputPath { get; set; } = null!;
+}

--- a/Registry.Web/Models/DTO/MultispectralDto.cs
+++ b/Registry.Web/Models/DTO/MultispectralDto.cs
@@ -61,6 +61,14 @@ public class MergeValidationResultDto
     public List<string> Errors { get; set; } = new();
     public List<string> Warnings { get; set; } = new();
     public MergeSummaryDto? Summary { get; set; }
+    public AlignmentStatusDto? Alignment { get; set; }
+}
+
+public class AlignmentStatusDto
+{
+    public bool Detected { get; set; }
+    public double MaxShiftPixels { get; set; }
+    public bool CorrectionApplied { get; set; }
 }
 
 public class MergeSummaryDto

--- a/Registry.Web/Models/DTO/MultispectralDto.cs
+++ b/Registry.Web/Models/DTO/MultispectralDto.cs
@@ -1,0 +1,76 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace Registry.Web.Models.DTO;
+
+/// <summary>
+/// DTO for raster sensor information response
+/// </summary>
+public class RasterInfoDto
+{
+    public int BandCount { get; set; }
+    public string? DataType { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+    public string? DetectedSensor { get; set; }
+    public List<BandInfoDto> Bands { get; set; } = new();
+    public List<PresetDto> AvailablePresets { get; set; } = new();
+    public string? DefaultPreset { get; set; }
+}
+
+public class BandInfoDto
+{
+    public int Index { get; set; }
+    public string? Name { get; set; }
+    public double? Wavelength { get; set; }
+    public string? ColorInterpretation { get; set; }
+}
+
+public class PresetDto
+{
+    public string? Id { get; set; }
+    public string? Name { get; set; }
+    public BandMappingDto? BandMapping { get; set; }
+    public bool IsDefault { get; set; }
+}
+
+public class BandMappingDto
+{
+    public int R { get; set; }
+    public int G { get; set; }
+    public int B { get; set; }
+}
+
+/// <summary>
+/// DTO for merge-multispectral request
+/// </summary>
+public class MergeMultispectralRequestDto
+{
+    public string[] Paths { get; set; } = [];
+    public string? PreviewBands { get; set; }
+    public int? ThumbSize { get; set; }
+    public string? OutputPath { get; set; }
+}
+
+/// <summary>
+/// DTO for merge-multispectral validation response
+/// </summary>
+public class MergeValidationResultDto
+{
+    public bool Ok { get; set; }
+    public List<string> Errors { get; set; } = new();
+    public List<string> Warnings { get; set; } = new();
+    public MergeSummaryDto? Summary { get; set; }
+}
+
+public class MergeSummaryDto
+{
+    public int TotalBands { get; set; }
+    public string? DataType { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+    public string? Crs { get; set; }
+    public double PixelSizeX { get; set; }
+    public double PixelSizeY { get; set; }
+    public long EstimatedSize { get; set; }
+}

--- a/Registry.Web/Registry.Web.csproj
+++ b/Registry.Web/Registry.Web.csproj
@@ -12,7 +12,7 @@
         <Platforms>AnyCPU;x64</Platforms>
         <PackageVersion>2.0.6</PackageVersion>
         <Configurations>Debug;Release;DebugEf</Configurations>
-        <DdbVersion>1.4.5</DdbVersion>
+        <DdbVersion>1.5.0</DdbVersion>
         <LangVersion>13</LangVersion>
     </PropertyGroup>
 

--- a/Registry.Web/Services/Managers/ObjectsManager.cs
+++ b/Registry.Web/Services/Managers/ObjectsManager.cs
@@ -1680,4 +1680,53 @@ public class ObjectsManager : IObjectsManager
     }
 
     #endregion
+
+    #region Thermal
+
+    public async Task<string> GetThermalInfo(string orgSlug, string dsSlug, string path)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Read))
+            throw new UnauthorizedException("The current user is not allowed to read dataset");
+
+        if (path.StartsWith('/')) path = path[1..];
+
+        var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
+        var sourcePath = GetBuildSource(entry);
+
+        return ddb.GetThermalInfo(sourcePath);
+    }
+
+    public async Task<string> GetThermalPoint(string orgSlug, string dsSlug, string path, int x, int y)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Read))
+            throw new UnauthorizedException("The current user is not allowed to read dataset");
+
+        if (path.StartsWith('/')) path = path[1..];
+
+        var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
+        var sourcePath = GetBuildSource(entry);
+
+        return ddb.GetThermalPoint(sourcePath, x, y);
+    }
+
+    public async Task<string> GetThermalAreaStats(string orgSlug, string dsSlug, string path, int x0, int y0, int x1, int y1)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Read))
+            throw new UnauthorizedException("The current user is not allowed to read dataset");
+
+        if (path.StartsWith('/')) path = path[1..];
+
+        var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
+        var sourcePath = GetBuildSource(entry);
+
+        return ddb.GetThermalAreaStats(sourcePath, x0, y0, x1, y1);
+    }
+
+    #endregion
 }

--- a/Registry.Web/Services/Managers/ObjectsManager.cs
+++ b/Registry.Web/Services/Managers/ObjectsManager.cs
@@ -233,7 +233,7 @@ public class ObjectsManager : IObjectsManager
             await stream.CopyToAsync(localFileStream);
 
         _logger.LogInformation("File saved, adding to DDB");
-        ddb.AddRaw(localFilePath);
+        ddb.AddRaw(path);
 
         _logger.LogInformation("Added to DDB, checking entry now...");
 
@@ -457,7 +457,7 @@ public class ObjectsManager : IObjectsManager
             fileSystemCopied = true;
 
             _logger.LogInformation("FS copy OK, performing ddb add");
-            destDdb.AddRaw(destDdb.GetLocalPath(destPath));
+            destDdb.AddRaw(destPath);
             addedToDdb = true;
 
             if (!destDdb.EntryExists(destPath))
@@ -1039,7 +1039,6 @@ public class ObjectsManager : IObjectsManager
         var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
 
         var sourcePath = GetBuildSource(entry);
-        var localPath = ddb.GetLocalPath(sourcePath);
 
         try
         {
@@ -1049,7 +1048,7 @@ public class ObjectsManager : IObjectsManager
             // We want to free up the main thread to handle other requests
             var tileData =
                 await _cacheManager.GetAsync(MagicStrings.TileCacheSeed, ForDataset(orgSlug, dsSlug), entry.Hash, tx, ty, tz, retina,
-                    new Func<Task<byte[]>>(() => Task.Run(() => ddb.GenerateTile(localPath, tz, tx, ty, retina, entry.Hash))));
+                    new Func<Task<byte[]>>(() => Task.Run(() => ddb.GenerateTile(sourcePath, tz, tx, ty, retina, entry.Hash))));
 
             return new StorageDataDto
             {
@@ -1523,7 +1522,6 @@ public class ObjectsManager : IObjectsManager
 
         var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
         var sourcePath = GetBuildSource(entry);
-        var localPath = ddb.GetLocalPath(sourcePath);
 
         var size = sizeRaw ?? _settings.DefaultThumbnailSize;
         var fileName = Path.GetFileName(path);
@@ -1534,7 +1532,7 @@ public class ObjectsManager : IObjectsManager
         var thumbData = await _cacheManager.GetAsync(MagicStrings.ThumbnailCacheSeed, ForDataset(orgSlug, dsSlug),
             entry.Hash, size, vizKey,
             new Func<Task<byte[]>>(() => Task.Run(() =>
-                ddb.GenerateThumbnailEx(localPath, size, preset, bands, formula, bandFilter, colormap, rescale))));
+                ddb.GenerateThumbnailEx(sourcePath, size, preset, bands, formula, bandFilter, colormap, rescale))));
 
         return new StorageDataDto
         {
@@ -1558,7 +1556,6 @@ public class ObjectsManager : IObjectsManager
 
         var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
         var sourcePath = GetBuildSource(entry);
-        var localPath = ddb.GetLocalPath(sourcePath);
 
         try
         {
@@ -1567,7 +1564,7 @@ public class ObjectsManager : IObjectsManager
             var tileData = await _cacheManager.GetAsync(MagicStrings.TileCacheSeed, ForDataset(orgSlug, dsSlug),
                 entry.Hash, tx, ty, tz, retina, vizKey,
                 new Func<Task<byte[]>>(() => Task.Run(() =>
-                    ddb.GenerateTileEx(localPath, tz, tx, ty, retina, entry.Hash,
+                    ddb.GenerateTileEx(sourcePath, tz, tx, ty, retina, entry.Hash,
                         preset, bands, formula, bandFilter, colormap, rescale))));
 
             return new StorageDataDto
@@ -1594,7 +1591,6 @@ public class ObjectsManager : IObjectsManager
             throw new UnauthorizedException("The current user is not allowed to read dataset");
 
         var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
-        var fullPaths = paths.Select(p => ddb.GetLocalPath(p)).ToArray();
 
         return await Task.Run(() => ddb.ValidateMergeMultispectral(paths));
     }
@@ -1636,7 +1632,7 @@ public class ObjectsManager : IObjectsManager
 
         _logger.LogInformation("Merging multispectral for '{OutputPath}'", outputFullPath);
 
-        await Task.Run(() => ddb.MergeMultispectral(paths, outputFullPath));
+        await Task.Run(() => ddb.MergeMultispectral(paths, outputPath));
 
         // Re-add the merged output to the index
         _ddbWrapper.Add(ddb.DatasetFolderPath, outputFullPath);
@@ -1657,13 +1653,12 @@ public class ObjectsManager : IObjectsManager
 
         var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
         var sourcePath = GetBuildSource(entry);
-        var localPath = ddb.GetLocalPath(sourcePath);
 
         var tempDir = Path.GetTempPath();
         var outputFileName = Path.GetFileNameWithoutExtension(path) + "_export.tif";
         var outputPath = Path.Combine(tempDir, outputFileName);
 
-        await Task.Run(() => ddb.ExportRaster(localPath, outputPath, preset, bands, formula,
+        await Task.Run(() => ddb.ExportRaster(sourcePath, outputPath, preset, bands, formula,
             bandFilter, colormap, rescale));
 
         var data = await File.ReadAllBytesAsync(outputPath);
@@ -1726,6 +1721,92 @@ public class ObjectsManager : IObjectsManager
         var sourcePath = GetBuildSource(entry);
 
         return ddb.GetThermalAreaStats(sourcePath, x0, y0, x1, y1);
+    }
+
+    #endregion
+
+    #region MaskBorders
+
+    public async Task<MaskBordersCheckResponseDto> CheckMaskedFileExists(string orgSlug, string dsSlug, string path)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Read))
+            throw new UnauthorizedException("The current user is not allowed to read dataset");
+
+        var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
+
+        var outputPath = GetMaskedOutputPath(path);
+        var entry = ddb.GetEntry(outputPath);
+
+        return new MaskBordersCheckResponseDto
+        {
+            Exists = entry != null,
+            OutputPath = outputPath
+        };
+    }
+
+    public async Task MaskBorders(string orgSlug, string dsSlug, string path, int nearDist, bool white)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Write))
+            throw new UnauthorizedException("The current user is not allowed to write to dataset");
+
+        await EnsureNoActiveJob(orgSlug, dsSlug, path, "MaskBorders");
+
+        var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
+
+        // Validate path
+        CommonUtils.ValidateRelativePath(path, ddb.DatasetFolderPath, nameof(path));
+
+        var entry = ddb.GetEntry(path);
+        if (entry == null)
+            throw new InvalidOperationException($"Cannot find entry: '{path}'");
+
+        if (entry.Type != EntryType.GeoRaster)
+            throw new InvalidOperationException($"Entry '{path}' is not a georaster");
+
+        var outputPath = GetMaskedOutputPath(path);
+        var outputFullPath = ddb.GetLocalPath(outputPath);
+
+        // Delete existing output file if present
+        if (_fs.Exists(outputFullPath))
+        {
+            _logger.LogInformation("Output file already exists, deleting: '{OutputPath}'", outputFullPath);
+            _fs.Delete(outputFullPath);
+        }
+
+        _logger.LogInformation("Masking borders for '{Path}' asynchronously", path);
+
+        var user = await _authManager.GetCurrentUser();
+        var meta = new IndexPayload(orgSlug, dsSlug, entry.Hash, user.Id, null, path);
+        var jobId = _backgroundJob.EnqueueIndexed(
+            () => HangfireUtils.MaskBordersWrapper(ddb, path, outputPath, nearDist, white, null), meta);
+
+        _logger.LogInformation("Background job id is {JobId}", jobId);
+    }
+
+    private static string GetMaskedOutputPath(string path)
+    {
+        var outputPath = Path.GetFileNameWithoutExtension(path) + "_masked.tif";
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir))
+            outputPath = Path.Combine(dir, outputPath).Replace('\\', '/');
+        return outputPath;
+    }
+
+    private async Task EnsureNoActiveJob(string orgSlug, string dsSlug, string path, string methodName)
+    {
+        var jobs = await _jobIndexQuery.GetByOrgDsAsync(orgSlug, dsSlug, 0, 1000);
+        var activeJob = jobs.FirstOrDefault(j =>
+            j.Path == path &&
+            j.CurrentState is "Enqueued" or "Processing" or "Scheduled" or "Created" &&
+            j.MethodDisplay != null && j.MethodDisplay.Contains(methodName));
+
+        if (activeJob != null)
+            throw new InvalidOperationException(
+                $"A {methodName} operation is already in progress for '{path}'");
     }
 
     #endregion

--- a/Registry.Web/Services/Managers/ObjectsManager.cs
+++ b/Registry.Web/Services/Managers/ObjectsManager.cs
@@ -1196,6 +1196,9 @@ public class ObjectsManager : IObjectsManager
 
         ddb = _ddbManager.Get(orgSlug, internalRef);
 
+        // Validate path to prevent path traversal
+        CommonUtils.ValidateRelativePath(path, ddb.DatasetFolderPath);
+
         var res = ddb.Search(path)?.ToArray();
 
         if (res == null || res.Length == 0)
@@ -1592,8 +1595,7 @@ public class ObjectsManager : IObjectsManager
         var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
 
         // Validate each input path to prevent path traversal
-        foreach (var p in paths)
-            CommonUtils.ValidateRelativePath(p, ddb.DatasetFolderPath);
+        CommonUtils.ValidateRelativePaths(paths, ddb.DatasetFolderPath);
 
         return await Task.Run(() => ddb.ValidateMergeMultispectral(paths));
     }
@@ -1610,8 +1612,7 @@ public class ObjectsManager : IObjectsManager
             var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
 
             // Validate each input path to prevent path traversal
-            foreach (var p in paths)
-                CommonUtils.ValidateRelativePath(p, ddb.DatasetFolderPath);
+            CommonUtils.ValidateRelativePaths(paths, ddb.DatasetFolderPath);
 
             return ddb.PreviewMergeMultispectral(paths, previewBands, thumbSize);
         });
@@ -1630,8 +1631,7 @@ public class ObjectsManager : IObjectsManager
         CommonUtils.ValidateRelativePath(outputPath, ddb.DatasetFolderPath);
 
         // Validate each input path to prevent path traversal
-        foreach (var p in paths)
-            CommonUtils.ValidateRelativePath(p, ddb.DatasetFolderPath);
+        CommonUtils.ValidateRelativePaths(paths, ddb.DatasetFolderPath);
 
         var outputFullPath = ddb.GetLocalPath(outputPath);
 

--- a/Registry.Web/Services/Managers/ObjectsManager.cs
+++ b/Registry.Web/Services/Managers/ObjectsManager.cs
@@ -1489,7 +1489,6 @@ public class ObjectsManager : IObjectsManager
 
         var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
         var sourcePath = GetBuildSource(entry);
-        var localPath = ddb.GetLocalPath(sourcePath);
 
         return ddb.GetRasterInfo(sourcePath);
     }
@@ -1592,6 +1591,10 @@ public class ObjectsManager : IObjectsManager
 
         var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
 
+        // Validate each input path to prevent path traversal
+        foreach (var p in paths)
+            CommonUtils.ValidateRelativePath(p, ddb.DatasetFolderPath);
+
         return await Task.Run(() => ddb.ValidateMergeMultispectral(paths));
     }
 
@@ -1605,6 +1608,11 @@ public class ObjectsManager : IObjectsManager
         return await Task.Run(() =>
         {
             var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
+
+            // Validate each input path to prevent path traversal
+            foreach (var p in paths)
+                CommonUtils.ValidateRelativePath(p, ddb.DatasetFolderPath);
+
             return ddb.PreviewMergeMultispectral(paths, previewBands, thumbSize);
         });
     }
@@ -1619,7 +1627,11 @@ public class ObjectsManager : IObjectsManager
         var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
 
         // Validate outputPath to prevent path traversal
-        CommonUtils.ValidateRelativePath(outputPath, ddb.DatasetFolderPath, nameof(outputPath));
+        CommonUtils.ValidateRelativePath(outputPath, ddb.DatasetFolderPath);
+
+        // Validate each input path to prevent path traversal
+        foreach (var p in paths)
+            CommonUtils.ValidateRelativePath(p, ddb.DatasetFolderPath);
 
         var outputFullPath = ddb.GetLocalPath(outputPath);
 
@@ -1634,8 +1646,8 @@ public class ObjectsManager : IObjectsManager
 
         await Task.Run(() => ddb.MergeMultispectral(paths, outputPath));
 
-        // Re-add the merged output to the index
-        _ddbWrapper.Add(ddb.DatasetFolderPath, outputFullPath);
+        // Re-add the merged output to the index through the IDDB abstraction
+        ddb.AddRaw(outputPath);
 
         _logger.LogInformation("Merge complete and file added to the dataset");
     }
@@ -1655,23 +1667,28 @@ public class ObjectsManager : IObjectsManager
         var sourcePath = GetBuildSource(entry);
 
         var tempDir = Path.GetTempPath();
+        var tempOutputFileName = Path.GetFileNameWithoutExtension(path) + "_export_" + Guid.NewGuid().ToString("N") + ".tif";
         var outputFileName = Path.GetFileNameWithoutExtension(path) + "_export.tif";
-        var outputPath = Path.Combine(tempDir, outputFileName);
+        var outputPath = Path.Combine(tempDir, tempOutputFileName);
 
-        await Task.Run(() => ddb.ExportRaster(sourcePath, outputPath, preset, bands, formula,
-            bandFilter, colormap, rescale));
-
-        var data = await File.ReadAllBytesAsync(outputPath);
-
-        // Clean up temp file
-        try { File.Delete(outputPath); } catch { /* ignore */ }
-
-        return new StorageDataDto
+        try
         {
-            Name = outputFileName,
-            Data = data,
-            ContentType = "image/tiff"
-        };
+            await Task.Run(() => ddb.ExportRaster(sourcePath, outputPath, preset, bands, formula,
+                bandFilter, colormap, rescale));
+
+            var data = await File.ReadAllBytesAsync(outputPath);
+
+            return new StorageDataDto
+            {
+                Name = outputFileName,
+                Data = data,
+                ContentType = "image/tiff"
+            };
+        }
+        finally
+        {
+            try { if (File.Exists(outputPath)) File.Delete(outputPath); } catch { /* ignore cleanup failures */ }
+        }
     }
 
     #endregion
@@ -1736,6 +1753,9 @@ public class ObjectsManager : IObjectsManager
 
         var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
 
+        // Validate path to prevent path traversal
+        CommonUtils.ValidateRelativePath(path, ddb.DatasetFolderPath);
+
         var outputPath = GetMaskedOutputPath(path);
         var entry = ddb.GetEntry(outputPath);
 
@@ -1758,7 +1778,7 @@ public class ObjectsManager : IObjectsManager
         var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
 
         // Validate path
-        CommonUtils.ValidateRelativePath(path, ddb.DatasetFolderPath, nameof(path));
+        CommonUtils.ValidateRelativePath(path, ddb.DatasetFolderPath);
 
         var entry = ddb.GetEntry(path);
         if (entry == null)

--- a/Registry.Web/Services/Managers/ObjectsManager.cs
+++ b/Registry.Web/Services/Managers/ObjectsManager.cs
@@ -1621,12 +1621,27 @@ public class ObjectsManager : IObjectsManager
             throw new UnauthorizedException("The current user is not allowed to write to dataset");
 
         var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
+
+        // Validate outputPath to prevent path traversal
+        CommonUtils.ValidateRelativePath(outputPath, ddb.DatasetFolderPath, nameof(outputPath));
+
         var outputFullPath = ddb.GetLocalPath(outputPath);
+
+        // Delete existing output file if present (overwrite)
+        if (_fs.Exists(outputFullPath))
+        {
+            _logger.LogInformation("Output file already exists, deleting: '{OutputPath}'", outputFullPath);
+            _fs.Delete(outputFullPath);
+        }
+
+        _logger.LogInformation("Merging multispectral for '{OutputPath}'", outputFullPath);
 
         await Task.Run(() => ddb.MergeMultispectral(paths, outputFullPath));
 
         // Re-add the merged output to the index
         _ddbWrapper.Add(ddb.DatasetFolderPath, outputFullPath);
+
+        _logger.LogInformation("Merge complete and file added to the dataset");
     }
 
     public async Task<StorageDataDto> ExportRaster(string orgSlug, string dsSlug, string path,

--- a/Registry.Web/Services/Managers/ObjectsManager.cs
+++ b/Registry.Web/Services/Managers/ObjectsManager.cs
@@ -1629,5 +1629,40 @@ public class ObjectsManager : IObjectsManager
         _ddbWrapper.Add(ddb.DatasetFolderPath, outputFullPath);
     }
 
+    public async Task<StorageDataDto> ExportRaster(string orgSlug, string dsSlug, string path,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Read))
+            throw new UnauthorizedException("The current user is not allowed to read dataset");
+
+        if (path.StartsWith('/')) path = path[1..];
+
+        var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
+        var sourcePath = GetBuildSource(entry);
+        var localPath = ddb.GetLocalPath(sourcePath);
+
+        var tempDir = Path.GetTempPath();
+        var outputFileName = Path.GetFileNameWithoutExtension(path) + "_export.tif";
+        var outputPath = Path.Combine(tempDir, outputFileName);
+
+        await Task.Run(() => ddb.ExportRaster(localPath, outputPath, preset, bands, formula,
+            bandFilter, colormap, rescale));
+
+        var data = await File.ReadAllBytesAsync(outputPath);
+
+        // Clean up temp file
+        try { File.Delete(outputPath); } catch { /* ignore */ }
+
+        return new StorageDataDto
+        {
+            Name = outputFileName,
+            Data = data,
+            ContentType = "image/tiff"
+        };
+    }
+
     #endregion
 }

--- a/Registry.Web/Services/Managers/ObjectsManager.cs
+++ b/Registry.Web/Services/Managers/ObjectsManager.cs
@@ -1476,4 +1476,158 @@ public class ObjectsManager : IObjectsManager
     }
 
     #endregion
+
+    #region Multispectral
+
+    public async Task<string> GetRasterInfo(string orgSlug, string dsSlug, string path)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Read))
+            throw new UnauthorizedException("The current user is not allowed to read dataset");
+
+        if (path.StartsWith('/')) path = path[1..];
+
+        var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
+        var sourcePath = GetBuildSource(entry);
+        var localPath = ddb.GetLocalPath(sourcePath);
+
+        return ddb.GetRasterInfo(sourcePath);
+    }
+
+    public async Task<string> GetRasterMetadata(string orgSlug, string dsSlug, string path, string? formula = null, string? bandFilter = null)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Read))
+            throw new UnauthorizedException("The current user is not allowed to read dataset");
+
+        if (path.StartsWith('/')) path = path[1..];
+
+        var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
+        var sourcePath = GetBuildSource(entry);
+
+        return ddb.GetRasterMetadata(sourcePath, formula, bandFilter);
+    }
+
+    public async Task<StorageDataDto> GenerateThumbnailDataEx(string orgSlug, string dsSlug, string path, int? sizeRaw,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Read))
+            throw new UnauthorizedException("The current user is not allowed to read dataset");
+
+        if (path.StartsWith('/')) path = path[1..];
+
+        var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
+        var sourcePath = GetBuildSource(entry);
+        var localPath = ddb.GetLocalPath(sourcePath);
+
+        var size = sizeRaw ?? _settings.DefaultThumbnailSize;
+        var fileName = Path.GetFileName(path);
+
+        // Build a viz-specific cache key
+        var vizKey = $"{preset}|{bands}|{formula}|{bandFilter}|{colormap}|{rescale}";
+
+        var thumbData = await _cacheManager.GetAsync(MagicStrings.ThumbnailCacheSeed, ForDataset(orgSlug, dsSlug),
+            entry.Hash, size, vizKey,
+            new Func<Task<byte[]>>(() => Task.Run(() =>
+                ddb.GenerateThumbnailEx(localPath, size, preset, bands, formula, bandFilter, colormap, rescale))));
+
+        return new StorageDataDto
+        {
+            Name = Path.ChangeExtension(fileName, "webp"),
+            Data = thumbData,
+            ContentType = _ddbWrapper.ThumbnailMimeType
+        };
+    }
+
+    public async Task<StorageDataDto> GenerateTileDataEx(string orgSlug, string dsSlug, string path,
+        int tz, int tx, int ty, bool retina,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Read))
+            throw new UnauthorizedException("The current user is not allowed to read dataset");
+
+        if (path.StartsWith('/')) path = path[1..];
+
+        var entry = EnsurePathValidity(orgSlug, ds.InternalRef, path, out var ddb);
+        var sourcePath = GetBuildSource(entry);
+        var localPath = ddb.GetLocalPath(sourcePath);
+
+        try
+        {
+            var vizKey = $"{preset}|{bands}|{formula}|{bandFilter}|{colormap}|{rescale}";
+
+            var tileData = await _cacheManager.GetAsync(MagicStrings.TileCacheSeed, ForDataset(orgSlug, dsSlug),
+                entry.Hash, tx, ty, tz, retina, vizKey,
+                new Func<Task<byte[]>>(() => Task.Run(() =>
+                    ddb.GenerateTileEx(localPath, tz, tx, ty, retina, entry.Hash,
+                        preset, bands, formula, bandFilter, colormap, rescale))));
+
+            return new StorageDataDto
+            {
+                Data = tileData,
+                ContentType = "image/webp",
+                Name = $"{ty}.webp"
+            };
+        }
+        catch (InvalidOperationException ex)
+        {
+            if (ex.InnerException != null &&
+                ex.InnerException.Message.Contains("Out of bounds", StringComparison.OrdinalIgnoreCase))
+                throw new NotFoundException("Tile out of bounds", ex);
+            throw;
+        }
+    }
+
+    public async Task<string> ValidateMergeMultispectral(string orgSlug, string dsSlug, string[] paths)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Read))
+            throw new UnauthorizedException("The current user is not allowed to read dataset");
+
+        var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
+        var fullPaths = paths.Select(p => ddb.GetLocalPath(p)).ToArray();
+
+        return await Task.Run(() => ddb.ValidateMergeMultispectral(paths));
+    }
+
+    public async Task<byte[]> PreviewMergeMultispectral(string orgSlug, string dsSlug, string[] paths, string? previewBands = null, int thumbSize = 512)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Read))
+            throw new UnauthorizedException("The current user is not allowed to read dataset");
+
+        return await Task.Run(() =>
+        {
+            var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
+            return ddb.PreviewMergeMultispectral(paths, previewBands, thumbSize);
+        });
+    }
+
+    public async Task MergeMultispectral(string orgSlug, string dsSlug, string[] paths, string outputPath)
+    {
+        var ds = _utils.GetDataset(orgSlug, dsSlug);
+
+        if (!await _authManager.RequestAccess(ds, AccessType.Write))
+            throw new UnauthorizedException("The current user is not allowed to write to dataset");
+
+        var ddb = _ddbManager.Get(orgSlug, ds.InternalRef);
+        var outputFullPath = ddb.GetLocalPath(outputPath);
+
+        await Task.Run(() => ddb.MergeMultispectral(paths, outputFullPath));
+
+        // Re-add the merged output to the index
+        _ddbWrapper.Add(ddb.DatasetFolderPath, outputFullPath);
+    }
+
+    #endregion
 }

--- a/Registry.Web/Services/Managers/SystemManager.cs
+++ b/Registry.Web/Services/Managers/SystemManager.cs
@@ -1025,7 +1025,7 @@ public class SystemManager : ISystemManager
                             try
                             {
                                 // Add file to DDB (this must be serial)
-                                ddb.AddRaw(result.LocalPath);
+                                ddb.AddRaw(result.Entry.Path);
                                 downloadedCount++;
                                 totalBytesDownloaded += result.BytesDownloaded;
 

--- a/Registry.Web/Services/Ports/IObjectsManager.cs
+++ b/Registry.Web/Services/Ports/IObjectsManager.cs
@@ -42,4 +42,30 @@ public interface IObjectsManager
     /// Invalidates all cached data for a dataset (tiles, thumbnails, dataset thumbnail, build-pending).
     /// </summary>
     Task InvalidateAllDatasetCaches(string orgSlug, string dsSlug);
+
+    /// <summary>Get raster info including bands, sensor profile, and presets</summary>
+    Task<string> GetRasterInfo(string orgSlug, string dsSlug, string path);
+
+    /// <summary>Get raster statistics and histogram for a band or formula</summary>
+    Task<string> GetRasterMetadata(string orgSlug, string dsSlug, string path, string? formula = null, string? bandFilter = null);
+
+    /// <summary>Generate thumbnail with extended visualization params</summary>
+    Task<StorageDataDto> GenerateThumbnailDataEx(string orgSlug, string dsSlug, string path, int? size,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null);
+
+    /// <summary>Generate tile with extended visualization params</summary>
+    Task<StorageDataDto> GenerateTileDataEx(string orgSlug, string dsSlug, string path,
+        int tz, int tx, int ty, bool retina,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null);
+
+    /// <summary>Validate merge-multispectral inputs</summary>
+    Task<string> ValidateMergeMultispectral(string orgSlug, string dsSlug, string[] paths);
+
+    /// <summary>Preview merge-multispectral result</summary>
+    Task<byte[]> PreviewMergeMultispectral(string orgSlug, string dsSlug, string[] paths, string? previewBands = null, int thumbSize = 512);
+
+    /// <summary>Merge single-band rasters into multi-band COG</summary>
+    Task MergeMultispectral(string orgSlug, string dsSlug, string[] paths, string outputPath);
 }

--- a/Registry.Web/Services/Ports/IObjectsManager.cs
+++ b/Registry.Web/Services/Ports/IObjectsManager.cs
@@ -68,4 +68,9 @@ public interface IObjectsManager
 
     /// <summary>Merge single-band rasters into multi-band COG</summary>
     Task MergeMultispectral(string orgSlug, string dsSlug, string[] paths, string outputPath);
+
+    /// <summary>Export raster with visualization params applied as GeoTIFF</summary>
+    Task<StorageDataDto> ExportRaster(string orgSlug, string dsSlug, string path,
+        string? preset = null, string? bands = null, string? formula = null,
+        string? bandFilter = null, string? colormap = null, string? rescale = null);
 }

--- a/Registry.Web/Services/Ports/IObjectsManager.cs
+++ b/Registry.Web/Services/Ports/IObjectsManager.cs
@@ -73,4 +73,13 @@ public interface IObjectsManager
     Task<StorageDataDto> ExportRaster(string orgSlug, string dsSlug, string path,
         string? preset = null, string? bands = null, string? formula = null,
         string? bandFilter = null, string? colormap = null, string? rescale = null);
+
+    /// <summary>Get thermal info including calibration, temperature range, and dimensions</summary>
+    Task<string> GetThermalInfo(string orgSlug, string dsSlug, string path);
+
+    /// <summary>Get temperature at a specific pixel location</summary>
+    Task<string> GetThermalPoint(string orgSlug, string dsSlug, string path, int x, int y);
+
+    /// <summary>Get temperature statistics for a rectangular area</summary>
+    Task<string> GetThermalAreaStats(string orgSlug, string dsSlug, string path, int x0, int y0, int x1, int y1);
 }

--- a/Registry.Web/Services/Ports/IObjectsManager.cs
+++ b/Registry.Web/Services/Ports/IObjectsManager.cs
@@ -82,4 +82,10 @@ public interface IObjectsManager
 
     /// <summary>Get temperature statistics for a rectangular area</summary>
     Task<string> GetThermalAreaStats(string orgSlug, string dsSlug, string path, int x0, int y0, int x1, int y1);
+
+    /// <summary>Check if a masked version of the orthophoto already exists</summary>
+    Task<MaskBordersCheckResponseDto> CheckMaskedFileExists(string orgSlug, string dsSlug, string path);
+
+    /// <summary>Mask orthophoto borders making them transparent</summary>
+    Task MaskBorders(string orgSlug, string dsSlug, string path, int nearDist, bool white);
 }

--- a/Registry.Web/Utilities/CacheProviderFactories.cs
+++ b/Registry.Web/Utilities/CacheProviderFactories.cs
@@ -16,15 +16,15 @@ public static class CacheProviderFactories
     /// Creates a cache provider function for tiles.
     /// </summary>
     /// <returns>
-    /// A function that takes parameters (fileHash, tx, ty, tz, retina, generateFunc)
+    /// A function that takes parameters (fileHash, tx, ty, tz, retina, [vizKey], generateFunc)
     /// and returns the tile data converted to WebP format.
     /// </returns>
     public static Func<object[], Task<byte[]>> CreateTileProvider()
     {
         return async parameters =>
         {
-            // Parameters: fileHash, tx, ty, tz, retina, generateFunc
-            var generateFunc = (Func<Task<byte[]>>)parameters[5];
+            // The generateFunc is always the last parameter
+            var generateFunc = (Func<Task<byte[]>>)parameters[^1];
             var data = await generateFunc();
             return data.ToWebp(90);
         };
@@ -34,7 +34,7 @@ public static class CacheProviderFactories
     /// Creates a cache provider function for thumbnails.
     /// </summary>
     /// <returns>
-    /// A function that takes parameters (fileHash, size, generateFunc)
+    /// A function that takes parameters (fileHash, size, [vizKey], generateFunc)
     /// and returns the thumbnail data.
     /// </returns>
     public static Func<object[], Task<byte[]>> CreateThumbnailProvider()
@@ -43,8 +43,8 @@ public static class CacheProviderFactories
         {
             try
             {
-                // Parameters: fileHash, size, generateFunc
-                var generateFunc = (Func<Task<byte[]>>)parameters[2];
+                // The generateFunc is always the last parameter
+                var generateFunc = (Func<Task<byte[]>>)parameters[^1];
                 return await generateFunc();
             }
             catch (Exception ex)

--- a/Registry.Web/Utilities/HangfireUtils.cs
+++ b/Registry.Web/Utilities/HangfireUtils.cs
@@ -225,7 +225,7 @@ public static class HangfireUtils
         ddb.MaskBorders(inputPath, outputPath, nearDist, white);
 
         writeLine("Adding masked file to index");
-        ddb.Add(outputPath);
+        ddb.AddRaw(outputPath);
 
         writeLine("Building COG for masked file");
         ddb.Build(outputPath);

--- a/Registry.Web/Utilities/HangfireUtils.cs
+++ b/Registry.Web/Utilities/HangfireUtils.cs
@@ -213,4 +213,24 @@ public static class HangfireUtils
         }
     }
 
+    [AutomaticRetry(Attempts = 1, OnAttemptsExceeded = AttemptsExceededAction.Fail)]
+    public static void MaskBordersWrapper(IDDB ddb, string inputPath, string outputPath,
+        int nearDist, bool white, PerformContext context)
+    {
+        Action<string> writeLine = context != null ? context.WriteLine : Log.Information;
+
+        writeLine($"In MaskBordersWrapper('{ddb.DatasetFolderPath}', '{inputPath}')");
+
+        writeLine("Running mask borders");
+        ddb.MaskBorders(inputPath, outputPath, nearDist, white);
+
+        writeLine("Adding masked file to index");
+        ddb.Add(outputPath);
+
+        writeLine("Building COG for masked file");
+        ddb.Build(outputPath);
+
+        writeLine("Done mask borders");
+    }
+
 }


### PR DESCRIPTION
- Add new Objects API endpoints + manager methods for raster info/metadata, extended tile/thumbnail generation, merge-multispectral, thermal queries, and mask-borders.
- Update caching provider logic to support an additional visualization cache key while keeping the generate function last.
- Extend the DroneDB wrapper (ports + native adapter) to enable the new capabilities.