### PR TITLE
Improve hub versioning

### DIFF
--- a/Registry.Web.Test/HubVersionComparerTest.cs
+++ b/Registry.Web.Test/HubVersionComparerTest.cs
@@ -1,0 +1,73 @@
+using NUnit.Framework;
+using Registry.Web.Services.Hub;
+using Shouldly;
+
+namespace Registry.Web.Test;
+
+[TestFixture]
+public class HubVersionComparerTest
+{
+    [TestCase(null, "2.0.0", true, TestName = "OnDisk null -> upgrade")]
+    [TestCase("", "2.0.0", true, TestName = "OnDisk empty -> upgrade")]
+    [TestCase("   ", "2.0.0", true, TestName = "OnDisk whitespace -> upgrade")]
+    [TestCase("garbage", "2.0.0", true, TestName = "OnDisk unparseable -> upgrade")]
+    [TestCase("1.9.9", "2.0.0", true, TestName = "Older patch -> upgrade")]
+    [TestCase("1.0.0", "2.0.0", true, TestName = "Older major -> upgrade")]
+    [TestCase("2.0.0", "2.0.1", true, TestName = "Older patch component -> upgrade")]
+    [TestCase("2.0.0", "2.0.0", false, TestName = "Same version -> keep")]
+    [TestCase("2.1.0", "2.0.0", false, TestName = "Newer on disk -> keep")]
+    [TestCase("3.0.0", "2.0.0", false, TestName = "Way newer on disk -> keep")]
+    [TestCase("2.0.0-beta", "2.0.0", false, TestName = "Pre-release suffix ignored on equal core")]
+    [TestCase("1.0.0-beta", "2.0.0", true, TestName = "Older with pre-release suffix -> upgrade")]
+    [TestCase("2", "2.0.0", false, TestName = "Single component padded -> equal")]
+    [TestCase("1.5", "2.0.0", true, TestName = "Two components padded older -> upgrade")]
+    public void ShouldUpgrade_Cases(string onDisk, string embedded, bool expected)
+    {
+        HubVersionComparer.ShouldUpgrade(onDisk, embedded).ShouldBe(expected);
+    }
+
+    [Test]
+    public void ShouldUpgrade_EmbeddedNullOrEmpty_ReturnsFalse()
+    {
+        HubVersionComparer.ShouldUpgrade("1.0.0", null).ShouldBeFalse();
+        HubVersionComparer.ShouldUpgrade("1.0.0", "").ShouldBeFalse();
+        HubVersionComparer.ShouldUpgrade("1.0.0", "garbage").ShouldBeFalse();
+    }
+
+    [Test]
+    public void TryParse_ValidSemver_Succeeds()
+    {
+        HubVersionComparer.TryParse("1.2.3", out var v).ShouldBeTrue();
+        v.Major.ShouldBe(1);
+        v.Minor.ShouldBe(2);
+        v.Build.ShouldBe(3);
+    }
+
+    [Test]
+    public void TryParse_StripsPreReleaseAndBuild()
+    {
+        HubVersionComparer.TryParse("1.2.3-rc.1+abc", out var v).ShouldBeTrue();
+        v.Major.ShouldBe(1);
+        v.Minor.ShouldBe(2);
+        v.Build.ShouldBe(3);
+    }
+
+    [Test]
+    public void TryParse_PadsMissingComponents()
+    {
+        HubVersionComparer.TryParse("1", out var v1).ShouldBeTrue();
+        v1.Build.ShouldBe(0);
+
+        HubVersionComparer.TryParse("1.2", out var v2).ShouldBeTrue();
+        v2.Build.ShouldBe(0);
+    }
+
+    [Test]
+    public void TryParse_Invalid_ReturnsFalse()
+    {
+        HubVersionComparer.TryParse(null, out _).ShouldBeFalse();
+        HubVersionComparer.TryParse("", out _).ShouldBeFalse();
+        HubVersionComparer.TryParse("garbage", out _).ShouldBeFalse();
+        HubVersionComparer.TryParse("a.b.c", out _).ShouldBeFalse();
+    }
+}

--- a/Registry.Web/Controllers/SystemController.cs
+++ b/Registry.Web/Controllers/SystemController.cs
@@ -329,6 +329,7 @@ public class SystemController : ControllerBaseEx
     /// Gets the status of all platform feature flags.
     /// </summary>
     /// <returns>An object with the status of each feature.</returns>
+    [AllowAnonymous]
     [HttpGet("features", Name = nameof(SystemController) + "." + nameof(GetFeatures))]
     [ProducesResponseType(typeof(FeaturesDto), StatusCodes.Status200OK)]
     public IActionResult GetFeatures()
@@ -350,7 +351,8 @@ public class SystemController : ControllerBaseEx
                 }
                 : null,
             DatasetThumbnailCandidates = _appSettings.DatasetThumbnailCandidates,
-            MaxExportSizeBytes = _appSettings.MaxExportSizeBytes
+            MaxExportSizeBytes = _appSettings.MaxExportSizeBytes,
+            HubOptions = _appSettings.HubOptions
         };
 
         return Ok(features);

--- a/Registry.Web/Controllers/SystemController.cs
+++ b/Registry.Web/Controllers/SystemController.cs
@@ -8,9 +8,11 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Registry.Ports;
 using Registry.Web.Models;
 using Registry.Web.Models.Configuration;
 using Registry.Web.Models.DTO;
+using Registry.Web.Services.Hub;
 using Registry.Web.Services.Ports;
 using Registry.Web.Utilities;
 
@@ -28,6 +30,7 @@ public class SystemController : ControllerBaseEx
     private readonly ISystemManager _systemManager;
     private readonly IDatasetsManager _datasetsManager;
     private readonly IOrganizationsManager _organizationsManager;
+    private readonly IDdbWrapper _ddbWrapper;
     private readonly ILogger<SystemController> _logger;
     private readonly AppSettings _appSettings;
 
@@ -35,12 +38,14 @@ public class SystemController : ControllerBaseEx
         ISystemManager systemManager,
         IDatasetsManager datasetsManager,
         IOrganizationsManager organizationsManager,
+        IDdbWrapper ddbWrapper,
         ILogger<SystemController> logger,
         IOptions<AppSettings> appSettings)
     {
         _systemManager = systemManager;
         _datasetsManager = datasetsManager;
         _organizationsManager = organizationsManager;
+        _ddbWrapper = ddbWrapper;
         _logger = logger;
         _appSettings = appSettings.Value;
     }
@@ -352,10 +357,28 @@ public class SystemController : ControllerBaseEx
                 : null,
             DatasetThumbnailCandidates = _appSettings.DatasetThumbnailCandidates,
             MaxExportSizeBytes = _appSettings.MaxExportSizeBytes,
-            HubOptions = _appSettings.HubOptions
+            HubOptions = _appSettings.HubOptions,
+            HubVersion = HubInfo.CurrentVersion,
+            RegistryVersion = _systemManager.GetVersion(),
+            DdbVersion = GetCleanDdbVersion()
         };
 
         return Ok(features);
+    }
+
+    private string GetCleanDdbVersion()
+    {
+        try
+        {
+            var raw = _ddbWrapper.GetVersion();
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+            // The native lib returns "<semver> <commit>" — keep only the semver.
+            return raw.Contains(' ') ? raw[..raw.IndexOf(' ')] : raw;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/Registry.Web/MagicStrings.cs
+++ b/Registry.Web/MagicStrings.cs
@@ -39,6 +39,24 @@ public static class MagicStrings
     public const string AppSettingsFileName = "appsettings.json";
     public const string AppSettingsDefaultFileName = "appsettings-default.json";
 
+    /// <summary>
+    /// Marker file dropped inside the embedded Hub archive (and therefore in the
+    /// extracted folder) carrying the Hub semantic version. Used by Registry to
+    /// decide whether the on-disk Hub needs to be re-extracted after an upgrade.
+    /// </summary>
+    public const string HubVersionFile = "version.txt";
+
+    /// <summary>
+    /// Folder under <c>StoragePath</c> hosting user-supplied branding assets
+    /// (logos, favicons, manifest). Preserved across Hub upgrades.
+    /// </summary>
+    public const string BrandingFolder = "branding";
+
+    /// <summary>
+    /// URL prefix at which the branding folder is served.
+    /// </summary>
+    public const string BrandingUrlPrefix = "/branding";
+
     public const string DdbReleasesPageUrl = "https://github.com/DroneDB/DroneDB/releases";
     public const string DdbInstallPageUrl = "https://docs.dronedb.app/download.html";
 }

--- a/Registry.Web/Models/Configuration/AppSettings.cs
+++ b/Registry.Web/Models/Configuration/AppSettings.cs
@@ -238,6 +238,13 @@ public class AppSettings
 #nullable restore
 
     /// <summary>
+    /// Hub UI branding and customization options exposed to the frontend at runtime.
+    /// </summary>
+#nullable enable
+    public HubOptions? HubOptions { get; set; }
+#nullable restore
+
+    /// <summary>
     /// Allowed CORS origins. When null or empty, all origins are allowed.
     /// </summary>
 #nullable enable

--- a/Registry.Web/Models/Configuration/FaviconOptions.cs
+++ b/Registry.Web/Models/Configuration/FaviconOptions.cs
@@ -1,0 +1,36 @@
+using Newtonsoft.Json;
+
+namespace Registry.Web.Models.Configuration;
+
+/// <summary>
+/// Modern minimal favicon / web-manifest configuration.
+/// Each href points to a publicly served URL — typical deployments drop the
+/// referenced files under <c>{StoragePath}/branding/</c> and reference them
+/// via the <c>/branding/...</c> URL prefix.
+/// </summary>
+public class FaviconOptions
+{
+    /// <summary>URL of the .ico fallback favicon.</summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string FaviconIco { get; set; }
+
+    /// <summary>URL of the 16×16 PNG favicon.</summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string Favicon16 { get; set; }
+
+    /// <summary>URL of the 32×32 PNG favicon.</summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string Favicon32 { get; set; }
+
+    /// <summary>URL of the 180×180 apple-touch-icon PNG.</summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string AppleTouchIcon { get; set; }
+
+    /// <summary>URL of the PWA web manifest (typically <c>site.webmanifest</c>).</summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string Manifest { get; set; }
+
+    /// <summary>Theme color emitted as <c>&lt;meta name="theme-color"&gt;</c>.</summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string ThemeColor { get; set; }
+}

--- a/Registry.Web/Models/Configuration/HubOptions.cs
+++ b/Registry.Web/Models/Configuration/HubOptions.cs
@@ -1,0 +1,77 @@
+using Newtonsoft.Json;
+
+namespace Registry.Web.Models.Configuration;
+
+/// <summary>
+/// User-customizable Hub branding and UI options.
+/// All values are surfaced to the Vue frontend through the
+/// <see cref="Models.DTO.FeaturesDto"/> (<c>GET /sys/features</c>) and exposed at
+/// runtime as <c>window.HubOptions</c>.
+/// </summary>
+/// <remarks>
+/// Null properties are omitted from the JSON payload to preserve the
+/// <c>HubOptions.X !== undefined</c> fallback semantics expected by the frontend.
+/// </remarks>
+public class HubOptions
+{
+    /// <summary>
+    /// URL of the navbar logo. Use a path under <c>/branding/...</c> to point to a
+    /// file dropped in <c>{StoragePath}/branding/</c>, or any absolute URL.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string AppLogo { get; set; }
+
+    /// <summary>
+    /// Display name used as the document title and as fallback when no logo is set.
+    /// When null, the frontend defaults to <c>DroneDB</c>.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string AppName { get; set; }
+
+    /// <summary>
+    /// Optional CSS icon class shown next to the app name when no logo is configured.
+    /// When null, the frontend defaults to <c>icon-dronedb</c>.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string AppIcon { get; set; }
+
+    /// <summary>
+    /// Whether to show the registration link on the login page. Default is <c>true</c>.
+    /// </summary>
+    public bool ShowRegistrationLink { get; set; } = true;
+
+    /// <summary>
+    /// Hides every dataset creation entry-point in the UI when <c>true</c>.
+    /// </summary>
+    public bool DisableDatasetCreation { get; set; }
+
+    /// <summary>
+    /// Hides storage usage info in the header when <c>true</c>.
+    /// </summary>
+    public bool DisableStorageInfo { get; set; }
+
+    /// <summary>
+    /// Hides account-management entry-points in the UI when <c>true</c>.
+    /// </summary>
+    public bool DisableAccountManagement { get; set; }
+
+    /// <summary>
+    /// When set, the UI is locked to a single organization slug
+    /// (typical of self-hosted single-tenant deployments).
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string SingleOrganization { get; set; }
+
+    /// <summary>
+    /// Hides organization-creation/edit entry-points when <c>true</c>.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public bool? ReadOnlyOrgs { get; set; }
+
+    /// <summary>
+    /// Optional favicon / web-manifest configuration. When null, the Hub falls
+    /// back to whatever default favicon ships with the embedded ClientApp.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public FaviconOptions Favicon { get; set; }
+}

--- a/Registry.Web/Models/Configuration/HubOptions.cs
+++ b/Registry.Web/Models/Configuration/HubOptions.cs
@@ -65,8 +65,7 @@ public class HubOptions
     /// <summary>
     /// Hides organization-creation/edit entry-points when <c>true</c>.
     /// </summary>
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public bool? ReadOnlyOrgs { get; set; }
+    public bool ReadOnlyOrgs { get; set; }
 
     /// <summary>
     /// Optional favicon / web-manifest configuration. When null, the Hub falls

--- a/Registry.Web/Models/DTO/FeaturesDto.cs
+++ b/Registry.Web/Models/DTO/FeaturesDto.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using Registry.Web.Models.Configuration;
+
 namespace Registry.Web.Models.DTO;
 
 /// <summary>
@@ -41,4 +43,10 @@ public class FeaturesDto
     /// Clients use this to disable the export button when the estimated output exceeds the limit.
     /// </summary>
     public long? MaxExportSizeBytes { get; set; }
+
+    /// <summary>
+    /// Hub UI branding and customization options. Materializes <c>window.HubOptions</c>
+    /// on the client. Null when no branding is configured (frontend uses defaults).
+    /// </summary>
+    public HubOptions? HubOptions { get; set; }
 }

--- a/Registry.Web/Models/DTO/FeaturesDto.cs
+++ b/Registry.Web/Models/DTO/FeaturesDto.cs
@@ -51,4 +51,21 @@ public class FeaturesDto
     /// explicitly removed the section from <c>appsettings.json</c>.
     /// </summary>
     public HubOptions? HubOptions { get; set; }
+
+    /// <summary>
+    /// Semver of the Hub (Vue ClientApp) currently extracted in <c>{StoragePath}/ClientApp/</c>.
+    /// The SPA compares this with its own build-time <c>__HUB_VERSION__</c> on boot
+    /// to detect a server-side upgrade/downgrade and force a hard reload.
+    /// </summary>
+    public string? HubVersion { get; set; }
+
+    /// <summary>
+    /// Registry assembly version. Surfaced for the post-update notice dialog.
+    /// </summary>
+    public string? RegistryVersion { get; set; }
+
+    /// <summary>
+    /// Native DroneDB library version. Surfaced for the post-update notice dialog.
+    /// </summary>
+    public string? DdbVersion { get; set; }
 }

--- a/Registry.Web/Models/DTO/FeaturesDto.cs
+++ b/Registry.Web/Models/DTO/FeaturesDto.cs
@@ -46,7 +46,9 @@ public class FeaturesDto
 
     /// <summary>
     /// Hub UI branding and customization options. Materializes <c>window.HubOptions</c>
-    /// on the client. Null when no branding is configured (frontend uses defaults).
+    /// on the client. Always populated from <c>AppSettings:HubOptions</c> in production
+    /// (defaults shipped via <c>appsettings-default.json</c>); only null if an admin has
+    /// explicitly removed the section from <c>appsettings.json</c>.
     /// </summary>
     public HubOptions? HubOptions { get; set; }
 }

--- a/Registry.Web/Program.cs
+++ b/Registry.Web/Program.cs
@@ -517,6 +517,11 @@ public class Program
 
         Directory.CreateDirectory(folder);
 
+        // The branding folder hosts user-supplied logos / favicons / manifest.
+        // It is created (empty) on first run and is NEVER touched by SetupHub(),
+        // so customizations survive Hub upgrades.
+        Directory.CreateDirectory(Path.Combine(folder, MagicStrings.BrandingFolder));
+
         if (deployDdb && !SetupDdb(folder, resetDdb))
         {
             CommonUtils.WriteLineColor(" !> Failed to deploy DDB to storage folder", ConsoleColor.Red);
@@ -576,21 +581,70 @@ public class Program
     private static bool SetupHub(string folder, bool resetSpa)
     {
         var hubRoot = Path.Combine(folder, MagicStrings.SpaRoot);
+        var embeddedVersion = ReadEmbeddedHubVersion();
+        var onDiskVersion = ReadOnDiskHubVersion(hubRoot);
 
         if (resetSpa)
         {
-            Console.WriteLine(" -> Resetting Hub");
+            Console.WriteLine(" -> Resetting Hub (--reset-spa)");
             if (Directory.Exists(hubRoot)) Directory.Delete(hubRoot, true);
-        }
-        else if (
-            Directory.Exists(hubRoot) &&
-            Directory.GetFiles(hubRoot).Length != 0)
-        {
-            Console.WriteLine(" ?> Hub folder is ok");
-            return true;
+            return ExtractHub(hubRoot, embeddedVersion);
         }
 
-        return ExtractHub(hubRoot);
+        var folderEmpty = !Directory.Exists(hubRoot) || Directory.GetFiles(hubRoot).Length == 0;
+        if (folderEmpty)
+        {
+            Console.WriteLine($" -> Installing Hub v{embeddedVersion ?? "unknown"}");
+            return ExtractHub(hubRoot, embeddedVersion);
+        }
+
+        if (Services.Hub.HubVersionComparer.ShouldUpgrade(onDiskVersion, embeddedVersion))
+        {
+            Console.WriteLine($" -> Upgrading Hub: {onDiskVersion ?? "unknown"} -> {embeddedVersion}");
+            Directory.Delete(hubRoot, true);
+            return ExtractHub(hubRoot, embeddedVersion);
+        }
+
+        Console.WriteLine($" ?> Hub folder is ok (v{onDiskVersion ?? "unknown"})");
+        return true;
+    }
+
+    /// <summary>
+    /// Reads the Hub version stamped inside the embedded ClientApp.zip.
+    /// Returns <c>null</c> if the marker file is missing (older ZIPs).
+    /// </summary>
+    private static string ReadEmbeddedHubVersion()
+    {
+        try
+        {
+            var efp = new EmbeddedResourceQuery();
+            using var stream = efp.Read(Assembly.GetExecutingAssembly(), MagicStrings.SpaRoot + ".zip");
+            if (stream == null) return null;
+            using var zip = new ZipArchive(stream, ZipArchiveMode.Read);
+            var entry = zip.GetEntry(MagicStrings.HubVersionFile);
+            if (entry == null) return null;
+            using var reader = new StreamReader(entry.Open());
+            return reader.ReadToEnd().Trim();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($" !> Failed to read embedded Hub version: {e.Message}");
+            return null;
+        }
+    }
+
+    private static string ReadOnDiskHubVersion(string hubRoot)
+    {
+        var path = Path.Combine(hubRoot, MagicStrings.HubVersionFile);
+        if (!File.Exists(path)) return null;
+        try
+        {
+            return File.ReadAllText(path).Trim();
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static bool SetupDdb(string folder, bool resetDdb)
@@ -662,9 +716,23 @@ public class Program
         return ExtractEmbeddedArchive(MagicStrings.DdbArchive, folder);
     }
 
-    private static bool ExtractHub(string folder)
+    private static bool ExtractHub(string folder, string embeddedVersion = null)
     {
-        return ExtractEmbeddedArchive(MagicStrings.SpaRoot, folder);
+        if (!ExtractEmbeddedArchive(MagicStrings.SpaRoot, folder)) return false;
+
+        // Defensive: ensure the version marker is written even if the embedded
+        // ZIP did not carry one (e.g. legacy build outputs).
+        if (!string.IsNullOrWhiteSpace(embeddedVersion))
+        {
+            var versionPath = Path.Combine(folder, MagicStrings.HubVersionFile);
+            if (!File.Exists(versionPath))
+            {
+                try { File.WriteAllText(versionPath, embeddedVersion); }
+                catch (Exception e) { Console.WriteLine($" !> Failed to write Hub version marker: {e.Message}"); }
+            }
+        }
+
+        return true;
     }
 
     private static JObject GetDefaultSettings()

--- a/Registry.Web/Program.cs
+++ b/Registry.Web/Program.cs
@@ -584,29 +584,35 @@ public class Program
         var embeddedVersion = ReadEmbeddedHubVersion();
         var onDiskVersion = ReadOnDiskHubVersion(hubRoot);
 
+        bool ok;
         if (resetSpa)
         {
             Console.WriteLine(" -> Resetting Hub (--reset-spa)");
             if (Directory.Exists(hubRoot)) Directory.Delete(hubRoot, true);
-            return ExtractHub(hubRoot, embeddedVersion);
+            ok = ExtractHub(hubRoot, embeddedVersion);
         }
-
-        var folderEmpty = !Directory.Exists(hubRoot) || Directory.GetFiles(hubRoot).Length == 0;
-        if (folderEmpty)
+        else if (!Directory.Exists(hubRoot) || Directory.GetFiles(hubRoot).Length == 0)
         {
             Console.WriteLine($" -> Installing Hub v{embeddedVersion ?? "unknown"}");
-            return ExtractHub(hubRoot, embeddedVersion);
+            ok = ExtractHub(hubRoot, embeddedVersion);
         }
-
-        if (Services.Hub.HubVersionComparer.ShouldUpgrade(onDiskVersion, embeddedVersion))
+        else if (Services.Hub.HubVersionComparer.ShouldUpgrade(onDiskVersion, embeddedVersion))
         {
             Console.WriteLine($" -> Upgrading Hub: {onDiskVersion ?? "unknown"} -> {embeddedVersion}");
             Directory.Delete(hubRoot, true);
-            return ExtractHub(hubRoot, embeddedVersion);
+            ok = ExtractHub(hubRoot, embeddedVersion);
+        }
+        else
+        {
+            Console.WriteLine($" ?> Hub folder is ok (v{onDiskVersion ?? "unknown"})");
+            ok = true;
         }
 
-        Console.WriteLine($" ?> Hub folder is ok (v{onDiskVersion ?? "unknown"})");
-        return true;
+        // Record the version that is actually on disk so /sys/features can
+        // expose it to the SPA for client-side update detection.
+        Services.Hub.HubInfo.Initialize(ReadOnDiskHubVersion(hubRoot) ?? embeddedVersion);
+
+        return ok;
     }
 
     /// <summary>

--- a/Registry.Web/Registry.Web.csproj
+++ b/Registry.Web/Registry.Web.csproj
@@ -168,8 +168,14 @@
         <PropertyGroup>
             <HubPackageJsonPath>$(ProjectDir)/ClientApp/package.json</HubPackageJsonPath>
             <HubVersion Condition="Exists('$(HubPackageJsonPath)')">$([System.Text.RegularExpressions.Regex]::Match($([System.IO.File]::ReadAllText('$(HubPackageJsonPath)')), '"version"\s*:\s*"([^"]+)"').Groups[1].Value)</HubVersion>
-            <HubVersion Condition="'$(HubVersion)' == ''">0.0.0</HubVersion>
         </PropertyGroup>
+
+        <Error
+            Condition="!Exists('$(HubPackageJsonPath)')"
+            Text="Hub package.json not found at '$(HubPackageJsonPath)'. Cannot stamp Hub version into ClientApp.zip." />
+        <Error
+            Condition="'$(HubVersion)' == ''"
+            Text="Failed to extract a 'version' field from '$(HubPackageJsonPath)'. Cannot stamp Hub version into ClientApp.zip." />
 
         <Message Text="Stamping Hub version $(HubVersion) into ClientApp.zip" Importance="high" />
 

--- a/Registry.Web/Registry.Web.csproj
+++ b/Registry.Web/Registry.Web.csproj
@@ -160,6 +160,24 @@
 
         <Delete Files="$(ProjectDir)/ClientApp.zip" />
 
+        <!--
+          Stamp the Hub semantic version (read from ClientApp/package.json) into the build
+          output so it ends up inside ClientApp.zip. Registry uses this marker to decide
+          whether the on-disk Hub needs to be re-extracted after an upgrade.
+        -->
+        <PropertyGroup>
+            <HubPackageJsonPath>$(ProjectDir)/ClientApp/package.json</HubPackageJsonPath>
+            <HubVersion Condition="Exists('$(HubPackageJsonPath)')">$([System.Text.RegularExpressions.Regex]::Match($([System.IO.File]::ReadAllText('$(HubPackageJsonPath)')), '"version"\s*:\s*"([^"]+)"').Groups[1].Value)</HubVersion>
+            <HubVersion Condition="'$(HubVersion)' == ''">0.0.0</HubVersion>
+        </PropertyGroup>
+
+        <Message Text="Stamping Hub version $(HubVersion) into ClientApp.zip" Importance="high" />
+
+        <WriteLinesToFile
+            File="$(ProjectDir)/ClientApp/build/version.txt"
+            Lines="$(HubVersion)"
+            Overwrite="true" />
+
         <ZipDirectory SourceDirectory="$(ProjectDir)/ClientApp/build" DestinationFile="$(ProjectDir)/ClientApp.zip" Overwrite="true" />
 
         <ItemGroup>

--- a/Registry.Web/Services/Hub/HubInfo.cs
+++ b/Registry.Web/Services/Hub/HubInfo.cs
@@ -1,0 +1,24 @@
+namespace Registry.Web.Services.Hub;
+
+/// <summary>
+/// Static holder for the current Hub (Vue ClientApp) version installed on disk.
+/// Populated once at startup by <c>Program.SetupHub()</c> and surfaced to clients
+/// via <c>FeaturesDto.HubVersion</c> so the SPA can detect a server-side upgrade
+/// (or downgrade) and force a full reload.
+/// </summary>
+public static class HubInfo
+{
+    /// <summary>
+    /// The Hub semver as read from <c>{StoragePath}/ClientApp/version.txt</c>.
+    /// <c>null</c> if the marker is missing (legacy installs).
+    /// </summary>
+    public static string CurrentVersion { get; private set; }
+
+    /// <summary>
+    /// Records the Hub version detected at startup. Idempotent; the latest call wins.
+    /// </summary>
+    public static void Initialize(string version)
+    {
+        CurrentVersion = string.IsNullOrWhiteSpace(version) ? null : version.Trim();
+    }
+}

--- a/Registry.Web/Services/Hub/HubVersionComparer.cs
+++ b/Registry.Web/Services/Hub/HubVersionComparer.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace Registry.Web.Services.Hub;
+
+/// <summary>
+/// Compares Hub semantic versions to decide whether the on-disk Hub
+/// needs to be replaced by the embedded one.
+/// </summary>
+/// <remarks>
+/// The comparison is intentionally lenient: any non-parseable on-disk version
+/// (missing file, blank string, malformed text) is treated as "older" and
+/// triggers a re-extraction. This guarantees the on-disk Hub is upgraded
+/// when transitioning from a Registry version that did not stamp a version,
+/// or when the marker file has been tampered with.
+/// </remarks>
+public static class HubVersionComparer
+{
+    /// <summary>
+    /// Returns <c>true</c> when the embedded Hub should overwrite the on-disk one.
+    /// </summary>
+    /// <param name="onDiskVersion">Content of the on-disk version marker, or <c>null</c> if missing.</param>
+    /// <param name="embeddedVersion">Version stamped into the embedded archive.</param>
+    public static bool ShouldUpgrade(string onDiskVersion, string embeddedVersion)
+    {
+        if (string.IsNullOrWhiteSpace(embeddedVersion))
+            return false;
+
+        if (!TryParse(embeddedVersion, out var embedded))
+            return false;
+
+        if (string.IsNullOrWhiteSpace(onDiskVersion))
+            return true;
+
+        if (!TryParse(onDiskVersion, out var onDisk))
+            return true;
+
+        return embedded > onDisk;
+    }
+
+    /// <summary>
+    /// Parses a semver-like string (major.minor.patch[-prerelease][+build]).
+    /// Pre-release and build suffixes are ignored — only the numeric core is compared.
+    /// </summary>
+    public static bool TryParse(string raw, out Version version)
+    {
+        version = null;
+        if (string.IsNullOrWhiteSpace(raw)) return false;
+
+        var trimmed = raw.Trim();
+
+        // Strip pre-release / build metadata
+        var dashIdx = trimmed.IndexOfAny(['-', '+']);
+        if (dashIdx >= 0) trimmed = trimmed[..dashIdx];
+
+        // Pad missing components: "1" → "1.0.0", "1.2" → "1.2.0"
+        var dots = 0;
+        foreach (var c in trimmed)
+            if (c == '.') dots++;
+        for (var i = dots; i < 2; i++) trimmed += ".0";
+
+        return Version.TryParse(trimmed, out version);
+    }
+}

--- a/Registry.Web/Startup.cs
+++ b/Registry.Web/Startup.cs
@@ -27,6 +27,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -449,6 +450,19 @@ public class Startup
 
         app.UseWhen(context => !context.Request.Path.StartsWithSegments("/static"), builder =>
         {
+            // Serve user-supplied branding assets (logos, favicons, manifest)
+            // from {StoragePath}/branding/ at /branding/*. This folder is
+            // preserved across Hub upgrades.
+            var brandingRoot = Path.GetFullPath(
+                Path.Combine(corsSettings.StoragePath ?? ".", MagicStrings.BrandingFolder));
+            Directory.CreateDirectory(brandingRoot);
+            builder.UseStaticFiles(new StaticFileOptions
+            {
+                FileProvider = new PhysicalFileProvider(brandingRoot),
+                RequestPath = MagicStrings.BrandingUrlPrefix,
+                ServeUnknownFileTypes = true
+            });
+
             builder.UseSpaStaticFiles(new StaticFileOptions
             {
                 ServeUnknownFileTypes = true,

--- a/Registry.Web/Startup.cs
+++ b/Registry.Web/Startup.cs
@@ -466,6 +466,21 @@ public class Startup
             builder.UseSpaStaticFiles(new StaticFileOptions
             {
                 ServeUnknownFileTypes = true,
+                OnPrepareResponse = ctx =>
+                {
+                    // Force browsers/proxies to revalidate index.html so a Hub
+                    // upgrade on the server is picked up by clients with a
+                    // stale cached document. Hashed JS/CSS chunks remain
+                    // cacheable.
+                    var path = ctx.File?.Name;
+                    if (string.Equals(path, "index.html", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var headers = ctx.Context.Response.Headers;
+                        headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+                        headers["Pragma"] = "no-cache";
+                        headers["Expires"] = "0";
+                    }
+                }
             });
 
             builder.UseSpa(spa =>

--- a/Registry.Web/appsettings-default.json
+++ b/Registry.Web/appsettings-default.json
@@ -47,6 +47,18 @@
       "RequireUppercase": false,
       "RequireLowercase": false,
       "RequireNonAlphanumeric": false
+    },
+    "HubOptions": {
+      "AppLogo": "/images/logo-banner.svg",
+      "AppName": null,
+      "AppIcon": null,
+      "ShowRegistrationLink": true,
+      "DisableDatasetCreation": false,
+      "DisableStorageInfo": false,
+      "DisableAccountManagement": false,
+      "SingleOrganization": null,
+      "ReadOnlyOrgs": null,
+      "Favicon": null
     }
   },
   "Serilog": {

--- a/Registry.Web/appsettings-default.json
+++ b/Registry.Web/appsettings-default.json
@@ -57,7 +57,7 @@
       "DisableStorageInfo": false,
       "DisableAccountManagement": false,
       "SingleOrganization": null,
-      "ReadOnlyOrgs": null,
+      "ReadOnlyOrgs": false,
       "Favicon": null
     }
   },


### PR DESCRIPTION
Versioning:

- Stamp ClientApp/build/version.txt from package.json during PreBuild
- HubVersionComparer.ShouldUpgrade() compares on-disk vs embedded versions
- On startup, re-extract Hub only when an upgrade is detected

Branding configuration:

- HubOptions/FaviconOptions DTOs in appsettings.json (defaults in appsettings-default.json)
- Served via existing /sys/features endpoint (now [AllowAnonymous] for login page)
- Frontend hubBranding.js applies HubOptions and injects favicon/manifest/theme-color

Branding folder:

- /branding/ static route mapped to {StoragePath}/branding (preserved across upgrades)
- Modern minimal favicon set: 16/32/.ico/apple-touch-180/manifest/theme-color