### PR TITLE
Add OrgSlug to ShareInitDto for flexible destination selection

### DIFF
--- a/Registry.Web/Models/DTO/ShareInitDto.cs
+++ b/Registry.Web/Models/DTO/ShareInitDto.cs
@@ -10,5 +10,12 @@ public class ShareInitDto
 {
     public string Tag { get; set; }
 
+    /// <summary>
+    /// Organization slug to create a new dataset in. Used when Tag is null.
+    /// Allows callers to specify a destination org without needing to supply
+    /// a full "org/dataset" tag (the dataset slug is auto-generated).
+    /// </summary>
+    public string OrgSlug { get; set; }
+
     public string DatasetName { get; set; }
 }

--- a/Registry.Web/Services/Managers/ShareManager.cs
+++ b/Registry.Web/Services/Managers/ShareManager.cs
@@ -219,6 +219,17 @@ public class ShareManager : IShareManager
         Dataset dataset;
         var tag = parameters.Tag.ToTag();
 
+        // If no tag is specified but OrgSlug is, treat it as "create new dataset in that org"
+        // This lets callers specify a destination org without requiring a full "org/dataset" tag.
+        if (tag == null && !string.IsNullOrWhiteSpace(parameters.OrgSlug))
+        {
+            if (!parameters.OrgSlug.IsValidSlug())
+                throw new BadRequestException($"Organization slug is not valid: '{parameters.OrgSlug}'");
+
+            // Use a synthetic tag with only the org; dataset slug is null so a new one is generated below
+            tag = new TagDto(parameters.OrgSlug, null);
+        }
+
         // No organization requested
         if (tag?.OrganizationSlug == null)
         {


### PR DESCRIPTION
Previously callers could only specify a destination via the Tag field ('org/dataset'), which required knowing both slugs up front. ToTag() rejects any string without exactly one slash, so sending 'orgslug' alone caused a FormatException -> HTTP 400.

Add OrgSlug to ShareInitDto and handle it in ShareManager.Initialize(): when Tag is null but OrgSlug is set, a new dataset with an auto-generated slug is created in the specified organization (same logic as the existing 'tag.DatasetSlug == null' branch but driven by the new field).

This unblocks the WebODM DroneDB plugin's 'Choose destination -> Create new dataset' flow, which sends orgSlug separately rather than abusing the tag field.