### PR TITLE
Add LDAP support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,7 +22,7 @@
 - Use Entity Framework Core with migrations. Two DbContexts: `RegistryContext` (app data) + `ApplicationDbContext : IdentityDbContext<User>` (auth/Identity). 4 separate migration projects at solution root: `Registry.Web.Data.SqliteMigrations`, `Registry.Web.Data.MySqlMigrations`, `Registry.Web.Identity.SqliteMigrations`, `Registry.Web.Identity.MySqlMigrations`. Provider resolved at runtime via config.
 - Return appropriate HTTP responses (e.g., `Ok()`, `BadRequest()`, `NotFound()`).
 - Controllers return DTOs only, never entities directly. Mapping is manual via extension methods `ToDto()` and `ToEntity()` in `Utilities/Extenders.cs` - **no AutoMapper**.
-- Architecture: Interface-first with `I*Manager` interfaces in `Services/Ports/`. Controllers depend only on these interfaces. Implementation lives in `Services/*.cs` and `Services/Adapters/`. This is a simplified port-adapter pattern.
+- Architecture: Interface-first with `I*Manager` interfaces split between `Registry.Web/Services/Ports/` (web layer) and `Registry.Ports/` (core adapters like `IDdbManager`, `ICacheManager`). Controllers depend only on these interfaces. Implementation lives in `Services/*.cs` and `Services/Adapters/`. This is a simplified port-adapter pattern.
 
 ## Vue.js Frontend (`Registry.Web/ClientApp`)
 
@@ -40,7 +40,7 @@
 - Use **composition API** (if applicable) for better scalability.
 - Validate all forms before submission.
 - UI: **PrimeVue v4.x** is the sole component library (Lara theme with custom DDB preset). Bootstrap 5 is used only for grid + utilities. No other UI libraries present.
-- State: Vuex for state management, composables in `src/composables/` for reusable logic.
+- State: Composables in `src/composables/` for reusable logic and state. No Vuex/Pinia — the app uses Vue composables directly.
 - API client: Functions in `src/api/` use axios instances with JWT interceptors.
 - Testing: **No unit test framework configured** (no Jest/Vitest). Only Playwright for E2E testing.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,9 @@ RUN apt-get update \
         libxext6 \
         libxrender1 \
         zlib1g \
+        libldap2 \
+        libldap-common \
+        libsasl2-2 \
     && curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 10.0 --runtime aspnetcore \
     && LATEST_RELEASE_URL=$(curl -s https://api.github.com/repos/DroneDB/DroneDB/releases/latest | grep "browser_download_url.*deb" | head -n 1 | cut -d '"' -f 4) \
     && echo "Downloading DroneDB from $LATEST_RELEASE_URL" \

--- a/Registry.Adapters/Archives/SharpCompressArchiveExtractor.cs
+++ b/Registry.Adapters/Archives/SharpCompressArchiveExtractor.cs
@@ -26,20 +26,20 @@ public sealed class SharpCompressArchiveExtractor : IArchiveExtractor
 {
     // Order matters: longer compound extensions must be tested before their suffixes.
     private static readonly string[] SupportedExtensions =
-    {
+    [
         ".tar.gz", ".tar.bz2", ".tar.xz",
         ".tgz", ".tbz2", ".txz",
         ".zip", ".rar", ".7z", ".tar",
         ".gz", ".bz2", ".xz"
-    };
+    ];
 
     private static readonly string[] CompressedTarExtensions =
-    {
+    [
         ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz"
-    };
+    ];
 
     // Single-stream formats that frequently carry no internal entry name.
-    private static readonly string[] SingleFileExtensions = { ".gz", ".bz2", ".xz" };
+    private static readonly string[] SingleFileExtensions = [".gz", ".bz2", ".xz"];
 
     public bool IsSupported(string fileName)
     {

--- a/Registry.Common/Registry.Common.csproj
+++ b/Registry.Common/Registry.Common.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="MimeTypes" Version="2.5.2">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>compile; runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Polly" Version="8.6.6" />

--- a/Registry.Ports/DroneDB/DdbCleanupResult.cs
+++ b/Registry.Ports/DroneDB/DdbCleanupResult.cs
@@ -14,11 +14,11 @@ public class DdbCleanupResult
     /// file no longer existed on the filesystem.
     /// </summary>
     [JsonProperty("entries")]
-    public string[] Entries { get; set; } = Array.Empty<string>();
+    public string[] Entries { get; set; } = [];
 
     /// <summary>
     /// Hashes of orphaned build artifacts that were removed.
     /// </summary>
     [JsonProperty("builds")]
-    public string[] Builds { get; set; } = Array.Empty<string>();
+    public string[] Builds { get; set; } = [];
 }

--- a/Registry.Web.Test/ArtifactCompletenessCheckerServiceTest.cs
+++ b/Registry.Web.Test/ArtifactCompletenessCheckerServiceTest.cs
@@ -57,7 +57,7 @@ public class ArtifactCompletenessCheckerServiceTest : TestBase
 
         var ddbMock = new Mock<IDDB>();
         ddbMock.Setup(x => x.Search(It.IsAny<string>(), true))
-            .Returns(new[] { new DdbEntry { Path = "readme.txt", Hash = "h1" } });
+            .Returns([new DdbEntry { Path = "readme.txt", Hash = "h1" }]);
         ddbMock.Setup(x => x.IsBuildable("readme.txt")).Returns(false);
 
         _ddbManagerMock.Setup(x => x.Get(It.IsAny<string>(), It.IsAny<Guid>()))
@@ -81,7 +81,7 @@ public class ArtifactCompletenessCheckerServiceTest : TestBase
 
         var ddbMock = new Mock<IDDB>();
         ddbMock.Setup(x => x.Search(It.IsAny<string>(), true))
-            .Returns(new[] { new DdbEntry { Path = "ortho.tif", Hash = "h2" } });
+            .Returns([new DdbEntry { Path = "ortho.tif", Hash = "h2" }]);
         ddbMock.Setup(x => x.IsBuildable("ortho.tif")).Returns(true);
         ddbMock.Setup(x => x.IsBuildActive("ortho.tif")).Returns(true);
 
@@ -106,7 +106,7 @@ public class ArtifactCompletenessCheckerServiceTest : TestBase
 
         var ddbMock = new Mock<IDDB>();
         ddbMock.Setup(x => x.Search(It.IsAny<string>(), true))
-            .Returns(new[] { new DdbEntry { Path = "ortho.tif", Hash = "h2" } });
+            .Returns([new DdbEntry { Path = "ortho.tif", Hash = "h2" }]);
         ddbMock.Setup(x => x.IsBuildable("ortho.tif")).Returns(true);
         ddbMock.Setup(x => x.IsBuildActive("ortho.tif")).Returns(false);
         ddbMock.Setup(x => x.IsBuildComplete("ortho.tif")).Returns(true);
@@ -131,7 +131,7 @@ public class ArtifactCompletenessCheckerServiceTest : TestBase
 
         var ddbMock = new Mock<IDDB>();
         ddbMock.Setup(x => x.Search(It.IsAny<string>(), true))
-            .Returns(new[] { new DdbEntry { Path = "layer.geojson", Hash = "h3" } });
+            .Returns([new DdbEntry { Path = "layer.geojson", Hash = "h3" }]);
         ddbMock.Setup(x => x.IsBuildable("layer.geojson")).Returns(true);
         ddbMock.Setup(x => x.IsBuildActive("layer.geojson")).Returns(false);
         ddbMock.Setup(x => x.IsBuildComplete("layer.geojson")).Returns(false);

--- a/Registry.Web.Test/BuildPendingServiceTest.cs
+++ b/Registry.Web.Test/BuildPendingServiceTest.cs
@@ -111,7 +111,7 @@ public class BuildPendingServiceTest : TestBase
         {
             Checksum = "test-checksum-456",
             Entries = [],
-            Meta = new List<string>()
+            Meta = []
         });
 
         _ddbManagerMock.Setup(x => x.Get(It.IsAny<string>(), It.IsAny<Guid>()))
@@ -154,7 +154,7 @@ public class BuildPendingServiceTest : TestBase
         {
             Checksum = "test-checksum-789",
             Entries = [],
-            Meta = new List<string>()
+            Meta = []
         });
 
         _ddbManagerMock.Setup(x => x.Get(It.IsAny<string>(), It.IsAny<Guid>()))
@@ -253,7 +253,7 @@ public class BuildPendingServiceTest : TestBase
         {
             Checksum = "new-stale-checksum",
             Entries = [],
-            Meta = new List<string>()
+            Meta = []
         });
 
         _ddbManagerMock.Setup(x => x.Get(It.IsAny<string>(), It.IsAny<Guid>()))

--- a/Registry.Web.Test/DatasetCleanupServiceTest.cs
+++ b/Registry.Web.Test/DatasetCleanupServiceTest.cs
@@ -46,7 +46,7 @@ public class DatasetCleanupServiceTest : TestBase
 
         // No active jobs
         _jobIndexQueryMock.Setup(x => x.GetByOrgDsAsync(orgSlug, dsSlug, 0, int.MaxValue, default))
-            .ReturnsAsync(Array.Empty<JobIndex>());
+            .ReturnsAsync([]);
 
         var service = new DatasetCleanupService(
             context,
@@ -122,7 +122,7 @@ public class DatasetCleanupServiceTest : TestBase
         entriesBefore.ShouldBe(3);
 
         _jobIndexQueryMock.Setup(x => x.GetByOrgDsAsync(orgSlug, dsSlug, 0, int.MaxValue, default))
-            .ReturnsAsync(Array.Empty<JobIndex>());
+            .ReturnsAsync([]);
 
         var service = new DatasetCleanupService(
             context,
@@ -153,7 +153,7 @@ public class DatasetCleanupServiceTest : TestBase
         await using var context = GetEmptyContext();
 
         _jobIndexQueryMock.Setup(x => x.GetByOrgDsAsync(orgSlug, dsSlug, 0, int.MaxValue, default))
-            .ReturnsAsync(Array.Empty<JobIndex>());
+            .ReturnsAsync([]);
 
         // Simulate filesystem delete failure (file locked)
         _ddbManagerMock.Setup(x => x.Delete(orgSlug, internalRef))

--- a/Registry.Web.Test/DatasetManagerTest.cs
+++ b/Registry.Web.Test/DatasetManagerTest.cs
@@ -592,7 +592,7 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act & Assert
-        var action = () => datasetsManager.MoveToOrganization("source-org", new[] { "dataset-1" }, "dest-org");
+        var action = () => datasetsManager.MoveToOrganization("source-org", ["dataset-1"], "dest-org");
         await Should.ThrowAsync<UnauthorizedException>(action);
     }
 
@@ -609,8 +609,8 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act & Assert
-        var action = () => datasetsManager.MoveToOrganization("", new[] { "dataset-1" }, "dest-org");
-        await Should.ThrowAsync<BadRequestException>(action);
+        Task<IEnumerable<MoveDatasetResultDto>> Action() => datasetsManager.MoveToOrganization("", ["dataset-1"], "dest-org");
+        await Should.ThrowAsync<BadRequestException>((Func<Task<IEnumerable<MoveDatasetResultDto>>>)Action);
     }
 
     [Test]
@@ -626,7 +626,7 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act & Assert
-        var action = () => datasetsManager.MoveToOrganization(null, new[] { "dataset-1" }, "dest-org");
+        var action = () => datasetsManager.MoveToOrganization(null, ["dataset-1"], "dest-org");
         await Should.ThrowAsync<BadRequestException>(action);
     }
 
@@ -643,7 +643,7 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act & Assert
-        var action = () => datasetsManager.MoveToOrganization("source-org", new[] { "dataset-1" }, "");
+        var action = () => datasetsManager.MoveToOrganization("source-org", ["dataset-1"], "");
         await Should.ThrowAsync<BadRequestException>(action);
     }
 
@@ -677,7 +677,7 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act & Assert
-        var action = () => datasetsManager.MoveToOrganization("source-org", Array.Empty<string>(), "dest-org");
+        var action = () => datasetsManager.MoveToOrganization("source-org", [], "dest-org");
         await Should.ThrowAsync<BadRequestException>(action);
     }
 
@@ -694,7 +694,7 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act & Assert
-        var action = () => datasetsManager.MoveToOrganization("source-org", new[] { "dataset-1" }, "source-org");
+        var action = () => datasetsManager.MoveToOrganization("source-org", ["dataset-1"], "source-org");
         await Should.ThrowAsync<BadRequestException>(action);
     }
 
@@ -716,7 +716,7 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act
-        var results = (await datasetsManager.MoveToOrganization("source-org", new[] { "dataset-1" }, "dest-org")).ToArray();
+        var results = (await datasetsManager.MoveToOrganization("source-org", ["dataset-1"], "dest-org")).ToArray();
 
         // Assert
         results.Length.ShouldBe(1);
@@ -754,7 +754,7 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act
-        var results = (await datasetsManager.MoveToOrganization("source-org", new[] { "dataset-1", "dataset-2" }, "dest-org")).ToArray();
+        var results = (await datasetsManager.MoveToOrganization("source-org", ["dataset-1", "dataset-2"], "dest-org")).ToArray();
 
         // Assert
         results.Length.ShouldBe(2);
@@ -782,7 +782,7 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act
-        var results = (await datasetsManager.MoveToOrganization("source-org", new[] { "non-existent-dataset" }, "dest-org")).ToArray();
+        var results = (await datasetsManager.MoveToOrganization("source-org", ["non-existent-dataset"], "dest-org")).ToArray();
 
         // Assert
         results.Length.ShouldBe(1);
@@ -810,7 +810,7 @@ public class DatasetManagerTest : TestBase
 
         // Act - Mix of existing and non-existing datasets
         var results = (await datasetsManager.MoveToOrganization("source-org",
-            new[] { "dataset-1", "non-existent", "dataset-2" }, "dest-org")).ToArray();
+            ["dataset-1", "non-existent", "dataset-2"], "dest-org")).ToArray();
 
         // Assert
         results.Length.ShouldBe(3);
@@ -833,7 +833,7 @@ public class DatasetManagerTest : TestBase
 
         // Act
         var results = (await datasetsManager.MoveToOrganization("source-org",
-            new[] { "conflicting-dataset" }, "dest-org", ConflictResolutionStrategy.HaltOnConflict)).ToArray();
+            ["conflicting-dataset"], "dest-org", ConflictResolutionStrategy.HaltOnConflict)).ToArray();
 
         // Assert
         results.Length.ShouldBe(1);
@@ -860,7 +860,7 @@ public class DatasetManagerTest : TestBase
 
         // Act
         var results = (await datasetsManager.MoveToOrganization("source-org",
-            new[] { "conflicting-dataset" }, "dest-org", ConflictResolutionStrategy.Rename)).ToArray();
+            ["conflicting-dataset"], "dest-org", ConflictResolutionStrategy.Rename)).ToArray();
 
         // Assert
         results.Length.ShouldBe(1);
@@ -895,7 +895,7 @@ public class DatasetManagerTest : TestBase
 
         // Act
         var results = (await datasetsManager.MoveToOrganization("source-org",
-            new[] { "conflicting-dataset" }, "dest-org", ConflictResolutionStrategy.Rename)).ToArray();
+            ["conflicting-dataset"], "dest-org", ConflictResolutionStrategy.Rename)).ToArray();
 
         // Assert
         results.Length.ShouldBe(1);
@@ -924,7 +924,7 @@ public class DatasetManagerTest : TestBase
 
         // Act
         var results = (await datasetsManager.MoveToOrganization("source-org",
-            new[] { "conflicting-dataset" }, "dest-org", ConflictResolutionStrategy.Overwrite)).ToArray();
+            ["conflicting-dataset"], "dest-org", ConflictResolutionStrategy.Overwrite)).ToArray();
 
         // Assert
         results.Length.ShouldBe(1);
@@ -958,7 +958,7 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act
-        var results = (await datasetsManager.MoveToOrganization("source-org", new[] { "dataset-1" }, "dest-org")).ToArray();
+        var results = (await datasetsManager.MoveToOrganization("source-org", ["dataset-1"], "dest-org")).ToArray();
 
         // Assert
         results.Length.ShouldBe(1);
@@ -982,7 +982,7 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act & Assert
-        var action = () => datasetsManager.MoveToOrganization("non-existent-org", new[] { "dataset-1" }, "dest-org");
+        var action = () => datasetsManager.MoveToOrganization("non-existent-org", ["dataset-1"], "dest-org");
         await Should.ThrowAsync<NotFoundException>(action);
     }
 
@@ -999,7 +999,7 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act & Assert
-        var action = () => datasetsManager.MoveToOrganization("source-org", new[] { "dataset-1" }, "non-existent-org");
+        var action = () => datasetsManager.MoveToOrganization("source-org", ["dataset-1"], "non-existent-org");
         await Should.ThrowAsync<NotFoundException>(action);
     }
 
@@ -1021,7 +1021,7 @@ public class DatasetManagerTest : TestBase
             _authManagerMock.Object, _cacheManager, fileSystemMock.Object, _backgroundJobMock.Object, _appSettingsMock.Object);
 
         // Act
-        await datasetsManager.MoveToOrganization("source-org", new[] { "dataset-1", "dataset-2" }, "dest-org");
+        await datasetsManager.MoveToOrganization("source-org", ["dataset-1", "dataset-2"], "dest-org");
 
         // Assert - Verify ClearCache was called for each moved dataset
         _stacManagerMock.Verify(x => x.ClearCache(It.IsAny<Dataset>()), Times.Exactly(2));
@@ -1046,7 +1046,7 @@ public class DatasetManagerTest : TestBase
 
         // Act - Move datasets, some will conflict, some won't
         var results = (await datasetsManager.MoveToOrganization("source-org",
-            new[] { "unique-dataset", "conflicting-dataset" }, "dest-org", ConflictResolutionStrategy.Rename)).ToArray();
+            ["unique-dataset", "conflicting-dataset"], "dest-org", ConflictResolutionStrategy.Rename)).ToArray();
 
         // Assert
         results.Length.ShouldBe(2);

--- a/Registry.Web.Test/DownloadLimitMiddlewareTest.cs
+++ b/Registry.Web.Test/DownloadLimitMiddlewareTest.cs
@@ -36,10 +36,9 @@ public class DownloadLimitMiddlewareTest : TestBase
 
         if (userId != null)
         {
-            context.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
-            {
+            context.User = new ClaimsPrincipal(new ClaimsIdentity([
                 new Claim(ClaimTypes.Name, userId)
-            }, "test"));
+            ], "test"));
         }
 
         return context;

--- a/Registry.Web.Test/JobIndexCleanupServiceTest.cs
+++ b/Registry.Web.Test/JobIndexCleanupServiceTest.cs
@@ -242,7 +242,7 @@ public class JobIndexCleanupServiceTest : TestBase
         var removed = await writer.DeleteTerminalForDatasetAsync("org1", "ds1", "archive-extract");
 
         // Assert
-        removed.ShouldBe(new[] { "extract-done" });
+        removed.ShouldBe(["extract-done"]);
 
         var remaining = await context.JobIndices.ToArrayAsync();
         remaining.ShouldContain(j => j.JobId == "build-done");

--- a/Registry.Web.Test/LdapLoginManagerIntegrationTest.cs
+++ b/Registry.Web.Test/LdapLoginManagerIntegrationTest.cs
@@ -230,7 +230,7 @@ public class LdapLoginManagerIntegrationTest
         BindPassword = ServicePass,
         SearchFilter = "(cn={0})",
         UserDnFormat = null,
-        AdminGroupDns = new[] { AdminGroupDn },
+        AdminGroupDns = [AdminGroupDn],
         EmailAttribute = "mail",
         DisplayNameAttribute = "givenName",
         GroupMembershipAttribute = "memberOf",

--- a/Registry.Web.Test/LdapLoginManagerIntegrationTest.cs
+++ b/Registry.Web.Test/LdapLoginManagerIntegrationTest.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Shouldly;
+using Registry.Web.HealthChecks;
+using Registry.Web.Identity;
+using Registry.Web.Models.Configuration;
+using Registry.Web.Services.Managers;
+
+namespace Registry.Web.Test;
+
+/// <summary>
+/// End-to-end tests for <see cref="LdapLoginManager"/> and <see cref="LdapHealthCheck"/> that run
+/// against a real LDAP server (glauth) started in a throw-away Docker container via Testcontainers.
+///
+/// Marked <see cref="ExplicitAttribute"/> because it requires a working Docker daemon and pulls the
+/// <c>glauth/glauth</c> image; it is therefore excluded from the default unit-test run and is intended
+/// to be executed deliberately (locally or in a Docker-enabled CI job).
+///
+/// glauth quirks relied upon here (verified against glauth v2.5.0):
+///  - User DN returned by a search is <c>cn=&lt;name&gt;,ou=&lt;primarygroup&gt;,ou=users,&lt;baseDN&gt;</c>.
+///  - <c>memberOf</c> values use the form <c>ou=&lt;group&gt;,ou=groups,&lt;baseDN&gt;</c>.
+///  - A bound user can only read attributes if granted a <c>search</c> capability; the service-account
+///    search path (BindDn) does not require the end user to have that capability.
+///  - glauth <b>accepts</b> anonymous binds, so the health check's "Degraded" branch (anonymous bind
+///    rejected by policy, as Active Directory does) cannot be reproduced here and is not asserted.
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+[Explicit("Requires Docker: starts a glauth LDAP server in a container.")]
+public class LdapLoginManagerIntegrationTest
+{
+    private const string GlauthImage = "glauth/glauth:v2.5.0";
+    private const ushort LdapPort = 3893;
+
+    private const string BaseDn = "dc=glauth,dc=com";
+    private const string ServiceUserDn = "cn=serviceuser,ou=svcaccts,dc=glauth,dc=com";
+    private const string AdminGroupDn = "ou=registry-admins,ou=groups,dc=glauth,dc=com";
+
+    private const string ServicePass = "ServiceP@ss1";
+    private const string UserPass = "UserP@ss1";
+    private const string AdminPass = "AdminP@ss1";
+
+    private IContainer _container;
+    private string _host;
+    private ushort _port;
+
+    [OneTimeSetUp]
+    public async Task StartLdapServer()
+    {
+        _container = new ContainerBuilder(GlauthImage)
+            .WithResourceMapping(Encoding.UTF8.GetBytes(BuildGlauthConfig()), "/app/config/config.cfg")
+            .WithPortBinding(LdapPort, true)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("LDAP server listening"))
+            .Build();
+
+        await _container.StartAsync();
+
+        _host = _container.Hostname;
+        _port = _container.GetMappedPublicPort(LdapPort);
+    }
+
+    [OneTimeTearDown]
+    public async Task StopLdapServer()
+    {
+        if (_container is not null)
+            await _container.DisposeAsync();
+    }
+
+    // -------------------------------------------------------------------------
+    // Authentication (service-account search path)
+    // -------------------------------------------------------------------------
+
+    [Test]
+    public async Task CheckAccess_ValidUser_ReturnsSuccessWithMappedMetadata()
+    {
+        var manager = CreateManager(BaseSettings());
+
+        var result = await manager.CheckAccess("jdoe", UserPass);
+
+        result.Success.ShouldBeTrue();
+        result.UserName.ShouldBe("jdoe");
+        result.Metadata["email"].ShouldBe("jdoe@example.com");
+        result.Metadata["displayName"].ShouldBe("John");
+        result.Metadata["authProvider"].ShouldBe("ldap");
+        ((string[])result.Metadata["roles"]).ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task CheckAccess_AdminGroupMember_ReceivesAdminRole()
+    {
+        var manager = CreateManager(BaseSettings());
+
+        var result = await manager.CheckAccess("alice", AdminPass);
+
+        result.Success.ShouldBeTrue();
+        ((string[])result.Metadata["roles"]).ShouldContain(ApplicationDbContext.AdminRoleName);
+    }
+
+    [Test]
+    public async Task CheckAccess_WrongPassword_Fails()
+    {
+        var manager = CreateManager(BaseSettings());
+
+        var result = await manager.CheckAccess("jdoe", "definitely-wrong");
+
+        result.Success.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task CheckAccess_UnknownUser_Fails()
+    {
+        var manager = CreateManager(BaseSettings());
+
+        var result = await manager.CheckAccess("ghost", "whatever");
+
+        result.Success.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task CheckAccess_EmptyCredentials_Fails()
+    {
+        var manager = CreateManager(BaseSettings());
+
+        (await manager.CheckAccess("", "")).Success.ShouldBeFalse();
+        (await manager.CheckAccess("jdoe", "")).Success.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task CheckAccess_LdapFilterInjection_Fails()
+    {
+        var manager = CreateManager(BaseSettings());
+
+        // A wildcard or filter-injection username must never authenticate: EscapeLdapFilter neutralises
+        // the special characters so the search matches nothing.
+        (await manager.CheckAccess("*", "whatever")).Success.ShouldBeFalse();
+        (await manager.CheckAccess("jdoe)(uid=*", UserPass)).Success.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task CheckAccess_Token_NotSupported()
+    {
+        var manager = CreateManager(BaseSettings());
+
+        (await manager.CheckAccess("any-token")).Success.ShouldBeFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Authentication (direct-bind / UserDnFormat path, no service account)
+    // -------------------------------------------------------------------------
+
+    [Test]
+    public async Task CheckAccess_UserDnFormatDirectBind_Succeeds()
+    {
+        var settings = BaseSettings();
+        settings.BindDn = null;
+        settings.BindPassword = null;
+        settings.UserDnFormat = "cn={0},ou=users,dc=glauth,dc=com";
+
+        var manager = CreateManager(settings);
+
+        var result = await manager.CheckAccess("jdoe", UserPass);
+
+        result.Success.ShouldBeTrue();
+        result.Metadata["email"].ShouldBe("jdoe@example.com");
+    }
+
+    [Test]
+    public async Task CheckAccess_UserDnFormatDirectBind_WrongPassword_Fails()
+    {
+        var settings = BaseSettings();
+        settings.BindDn = null;
+        settings.BindPassword = null;
+        settings.UserDnFormat = "cn={0},ou=users,dc=glauth,dc=com";
+
+        var manager = CreateManager(settings);
+
+        (await manager.CheckAccess("jdoe", "definitely-wrong")).Success.ShouldBeFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Health check
+    // -------------------------------------------------------------------------
+
+    [Test]
+    public async Task LdapHealthCheck_WithServiceBind_IsHealthy()
+    {
+        var healthCheck = new LdapHealthCheck(Wrap(BaseSettings()));
+
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Test]
+    public async Task LdapHealthCheck_UnreachableServer_IsUnhealthy()
+    {
+        var settings = BaseSettings();
+        settings.Port = 1; // nothing is listening here
+        settings.Timeout = 3;
+
+        var healthCheck = new LdapHealthCheck(Wrap(settings));
+
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private LdapSettings BaseSettings() => new()
+    {
+        Enabled = true,
+        Server = _host,
+        Port = _port,
+        UseSsl = false,
+        ValidateSslCertificate = false,
+        BaseDn = BaseDn,
+        BindDn = ServiceUserDn,
+        BindPassword = ServicePass,
+        SearchFilter = "(cn={0})",
+        UserDnFormat = null,
+        AdminGroupDns = new[] { AdminGroupDn },
+        EmailAttribute = "mail",
+        DisplayNameAttribute = "givenName",
+        GroupMembershipAttribute = "memberOf",
+        Timeout = 15
+    };
+
+    private static LdapLoginManager CreateManager(LdapSettings settings) =>
+        new(NullLogger<LdapLoginManager>.Instance, Wrap(settings));
+
+    private static IOptions<AppSettings> Wrap(LdapSettings settings) =>
+        Microsoft.Extensions.Options.Options.Create(new AppSettings { LdapSettings = settings });
+
+    /// <summary>
+    /// Builds a minimal glauth "config" datastore. Passwords are stored as their SHA-256 hashes
+    /// (glauth's <c>passsha256</c>) computed here so the plaintext stays in one place.
+    /// <para/>
+    /// Group layout: <c>users</c> (5501), <c>registry-admins</c> (5502), <c>svcaccts</c> (5503).
+    /// - <c>serviceuser</c> binds and searches (has the <c>search</c> capability).
+    /// - <c>jdoe</c> is a normal user (primary group <c>users</c>); it also has a <c>search</c>
+    ///   capability so the direct-bind / UserDnFormat path can read its own attributes.
+    /// - <c>alice</c> is an admin: primary group <c>users</c> plus <c>registry-admins</c> via
+    ///   <c>othergroups</c>, producing the <c>memberOf</c> entry matched by <see cref="AdminGroupDn"/>.
+    /// </summary>
+    private static string BuildGlauthConfig() => $$"""
+        [ldap]
+          enabled = true
+          listen = "0.0.0.0:3893"
+        [ldaps]
+          enabled = false
+        [backend]
+          datastore = "config"
+          baseDN = "dc=glauth,dc=com"
+        [[users]]
+          name = "serviceuser"
+          uidnumber = 5003
+          primarygroup = 5503
+          passsha256 = "{{Sha256Hex(ServicePass)}}"
+            [[users.capabilities]]
+            action = "search"
+            object = "*"
+        [[users]]
+          name = "jdoe"
+          givenname = "John"
+          sn = "Doe"
+          mail = "jdoe@example.com"
+          uidnumber = 5002
+          primarygroup = 5501
+          passsha256 = "{{Sha256Hex(UserPass)}}"
+            [[users.capabilities]]
+            action = "search"
+            object = "*"
+        [[users]]
+          name = "alice"
+          givenname = "Alice"
+          sn = "Admin"
+          mail = "alice@example.com"
+          uidnumber = 5004
+          primarygroup = 5501
+          othergroups = [ 5502 ]
+          passsha256 = "{{Sha256Hex(AdminPass)}}"
+        [[groups]]
+          name = "users"
+          gidnumber = 5501
+        [[groups]]
+          name = "registry-admins"
+          gidnumber = 5502
+        [[groups]]
+          name = "svcaccts"
+          gidnumber = 5503
+        """;
+
+    private static string Sha256Hex(string value) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+}

--- a/Registry.Web.Test/NodeOdmTests.cs
+++ b/Registry.Web.Test/NodeOdmTests.cs
@@ -187,7 +187,7 @@ public class NodeOdmTests
     private sealed class StubHandler : HttpMessageHandler
     {
         private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
-        public List<HttpRequestMessage> Requests { get; } = new();
+        public List<HttpRequestMessage> Requests { get; } = [];
 
         public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
 
@@ -251,7 +251,7 @@ public class NodeOdmTests
             var client = ClientFor(handler);
             var node = new NodeOdmEndpoint("n", "http://node:3000", null, null);
 
-            var uuid = await client.CreateTaskAsync(node, "my-task", new[] { tempImg }, "[]", CancellationToken.None);
+            var uuid = await client.CreateTaskAsync(node, "my-task", [tempImg], "[]", CancellationToken.None);
 
             uuid.ShouldBe("task-xyz");
             handler.Requests[0].Method.ShouldBe(HttpMethod.Post);
@@ -268,7 +268,7 @@ public class NodeOdmTests
     {
         var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new ByteArrayContent(new byte[] { 1, 2, 3, 4 })
+            Content = new ByteArrayContent([1, 2, 3, 4])
         });
         var client = ClientFor(handler);
         var node = new NodeOdmEndpoint("n", "http://node:3000", null, null);

--- a/Registry.Web.Test/ObjectManagerTest.cs
+++ b/Registry.Web.Test/ObjectManagerTest.cs
@@ -1442,7 +1442,7 @@ public class ObjectManagerTest : TestBase
                 ? Directory.GetFiles(destDatasetPath, "*", SearchOption.AllDirectories)
                     .Where(f => !f.Contains(".ddb"))
                     .ToArray()
-                : Array.Empty<string>();
+                : [];
 
             allDestFiles.ShouldBeEmpty(
                 "no files from failed transfer should remain in destination");

--- a/Registry.Web.Test/Ogc/OgcLayerCatalogTests.cs
+++ b/Registry.Web.Test/Ogc/OgcLayerCatalogTests.cs
@@ -70,7 +70,7 @@ public class OgcLayerCatalogTests
     public async Task GetLayersAsync_MultiLayerGpkg_ExpandsToOneDtoPerInnerLayer()
     {
         var entry = VectorEntry();
-        _ddb.Setup(d => d.Search(string.Empty, true)).Returns(new[] { entry });
+        _ddb.Setup(d => d.Search(string.Empty, true)).Returns([entry]);
 
         _artifacts.Setup(a => a.GetVectorQueryPath(_ddb.Object, entry.Hash)).Returns("/tmp/source.gpkg");
         _artifacts.Setup(a => a.ArtifactExists("/tmp/source.gpkg")).Returns(true);
@@ -86,17 +86,17 @@ public class OgcLayerCatalogTests
         result[0].Name.ShouldBe("layer.geojson:roads");
         result[0].InnerLayerName.ShouldBe("roads");
         result[0].GeometryType.ShouldBe("LineString");
-        result[0].BboxWgs84.ShouldBe(new[] { 1.0, 2.0, 3.0, 4.0 });
+        result[0].BboxWgs84.ShouldBe([1.0, 2.0, 3.0, 4.0]);
         result[1].Name.ShouldBe("layer.geojson:poi");
         result[1].InnerLayerName.ShouldBe("poi");
-        result[1].BboxWgs84.ShouldBe(new[] { 5.0, 6.0, 7.0, 8.0 });
+        result[1].BboxWgs84.ShouldBe([5.0, 6.0, 7.0, 8.0]);
     }
 
     [Test]
     public async Task GetLayersAsync_VectorArtifactMissing_FallsBackToSingleEntryLayer()
     {
         var entry = VectorEntry();
-        _ddb.Setup(d => d.Search(string.Empty, true)).Returns(new[] { entry });
+        _ddb.Setup(d => d.Search(string.Empty, true)).Returns([entry]);
         _artifacts.Setup(a => a.GetVectorQueryPath(_ddb.Object, entry.Hash)).Returns("/tmp/source.gpkg");
         _artifacts.Setup(a => a.ArtifactExists(It.IsAny<string>())).Returns(false);
 
@@ -113,7 +113,7 @@ public class OgcLayerCatalogTests
     public async Task GetLayersAsync_DescribeVectorThrows_FallsBackToSingleEntryLayer()
     {
         var entry = VectorEntry();
-        _ddb.Setup(d => d.Search(string.Empty, true)).Returns(new[] { entry });
+        _ddb.Setup(d => d.Search(string.Empty, true)).Returns([entry]);
         _artifacts.Setup(a => a.GetVectorQueryPath(_ddb.Object, entry.Hash)).Returns("/tmp/source.gpkg");
         _artifacts.Setup(a => a.ArtifactExists(It.IsAny<string>())).Returns(true);
         _wrapper.Setup(w => w.DescribeVector(It.IsAny<string>(), It.IsAny<string>()))
@@ -131,7 +131,7 @@ public class OgcLayerCatalogTests
     public async Task GetLayersAsync_DescribeVectorReturnsEmptyLayers_FallsBackToSingleEntryLayer()
     {
         var entry = VectorEntry();
-        _ddb.Setup(d => d.Search(string.Empty, true)).Returns(new[] { entry });
+        _ddb.Setup(d => d.Search(string.Empty, true)).Returns([entry]);
         _artifacts.Setup(a => a.GetVectorQueryPath(_ddb.Object, entry.Hash)).Returns("/tmp/source.gpkg");
         _artifacts.Setup(a => a.ArtifactExists(It.IsAny<string>())).Returns(true);
         _wrapper.Setup(w => w.DescribeVector(It.IsAny<string>(), It.IsAny<string>()))
@@ -149,7 +149,7 @@ public class OgcLayerCatalogTests
     {
         var img = new Entry { Path = "img.jpg", Hash = "h", Type = EntryType.Image };
         var raster = new Entry { Path = "ortho.tif", Hash = "hr", Type = EntryType.GeoRaster };
-        _ddb.Setup(d => d.Search(string.Empty, true)).Returns(new[] { img, raster });
+        _ddb.Setup(d => d.Search(string.Empty, true)).Returns([img, raster]);
 
         var result = await _catalog.GetLayersAsync(Org, Ds);
 
@@ -188,7 +188,7 @@ public class OgcLayerCatalogTests
     public async Task ResolveAsync_ExactMatch_ReturnsInnerLayer()
     {
         var entry = VectorEntry();
-        _ddb.Setup(d => d.Search(string.Empty, true)).Returns(new[] { entry });
+        _ddb.Setup(d => d.Search(string.Empty, true)).Returns([entry]);
         _artifacts.Setup(a => a.GetVectorQueryPath(_ddb.Object, entry.Hash)).Returns("/tmp/source.gpkg");
         _artifacts.Setup(a => a.ArtifactExists(It.IsAny<string>())).Returns(true);
         _wrapper.Setup(w => w.DescribeVector(It.IsAny<string>(), It.IsAny<string>()))
@@ -204,7 +204,7 @@ public class OgcLayerCatalogTests
     public async Task ResolveAsync_BareEntryPath_FallsBackToFirstInnerLayer()
     {
         var entry = VectorEntry();
-        _ddb.Setup(d => d.Search(string.Empty, true)).Returns(new[] { entry });
+        _ddb.Setup(d => d.Search(string.Empty, true)).Returns([entry]);
         _artifacts.Setup(a => a.GetVectorQueryPath(_ddb.Object, entry.Hash)).Returns("/tmp/source.gpkg");
         _artifacts.Setup(a => a.ArtifactExists(It.IsAny<string>())).Returns(true);
         _wrapper.Setup(w => w.DescribeVector(It.IsAny<string>(), It.IsAny<string>()))
@@ -222,7 +222,7 @@ public class OgcLayerCatalogTests
     public async Task ResolveAsync_NamespacedPrefix_StripsAndResolves()
     {
         var raster = new Entry { Path = "ortho.tif", Hash = "hr", Type = EntryType.GeoRaster };
-        _ddb.Setup(d => d.Search(string.Empty, true)).Returns(new[] { raster });
+        _ddb.Setup(d => d.Search(string.Empty, true)).Returns([raster]);
 
         var resolved = await _catalog.ResolveAsync(Org, Ds, "ddb:ortho.tif");
 
@@ -233,7 +233,7 @@ public class OgcLayerCatalogTests
     [Test]
     public async Task ResolveAsync_UnknownLayer_ReturnsNull()
     {
-        _ddb.Setup(d => d.Search(string.Empty, true)).Returns(Array.Empty<Entry>());
+        _ddb.Setup(d => d.Search(string.Empty, true)).Returns([]);
         var resolved = await _catalog.ResolveAsync(Org, Ds, "nope");
         resolved.ShouldBeNull();
     }
@@ -242,7 +242,7 @@ public class OgcLayerCatalogTests
     public async Task GetLayersAsync_CachesResultsAcrossCalls()
     {
         var entry = new Entry { Path = "ortho.tif", Hash = "hr", Type = EntryType.GeoRaster };
-        _ddb.Setup(d => d.Search(string.Empty, true)).Returns(new[] { entry });
+        _ddb.Setup(d => d.Search(string.Empty, true)).Returns([entry]);
 
         var first = await _catalog.GetLayersAsync(Org, Ds);
         var second = await _catalog.GetLayersAsync(Org, Ds);

--- a/Registry.Web.Test/Ogc/WmsValidatorTest.cs
+++ b/Registry.Web.Test/Ogc/WmsValidatorTest.cs
@@ -89,7 +89,7 @@ public class WmsValidatorTest
     {
         Should.Throw<OgcException>(() => WmsValidator.ValidateLayers(null))
             .Code.ShouldBe("MissingParameterValue");
-        Should.Throw<OgcException>(() => WmsValidator.ValidateLayers(System.Array.Empty<string>()))
+        Should.Throw<OgcException>(() => WmsValidator.ValidateLayers([]))
             .Code.ShouldBe("MissingParameterValue");
     }
 
@@ -111,7 +111,7 @@ public class WmsValidatorTest
     public void ValidateStyles_AllowsEmptyAndDefault()
     {
         Should.NotThrow(() => WmsValidator.ValidateStyles(
-            new[] { "", "default" }, new[] { "a", "b" }, _ => null));
+            ["", "default"], ["a", "b"], _ => null));
     }
 
     [Test]
@@ -125,7 +125,7 @@ public class WmsValidatorTest
             BandCount = 3
         };
         var ex = Should.Throw<OgcException>(() => WmsValidator.ValidateStyles(
-            new[] { "NDVI" }, new[] { "ortho" }, name => layer));
+            ["NDVI"], ["ortho"], name => layer));
         ex.Code.ShouldBe("StyleNotDefined");
         ex.Locator.ShouldBe("STYLES");
     }
@@ -141,14 +141,14 @@ public class WmsValidatorTest
             BandCount = 5
         };
         Should.NotThrow(() => WmsValidator.ValidateStyles(
-            new[] { "NDVI" }, new[] { "msi" }, name => layer));
+            ["NDVI"], ["msi"], name => layer));
     }
 
     [Test]
     public void ValidateStyles_RejectsUnknownStyle()
     {
         var ex = Should.Throw<OgcException>(() => WmsValidator.ValidateStyles(
-            new[] { "thermal" }, new[] { "any" }, _ => null));
+            ["thermal"], ["any"], _ => null));
         ex.Code.ShouldBe("StyleNotDefined");
     }
 
@@ -156,7 +156,7 @@ public class WmsValidatorTest
     public void ValidateStyles_RejectsSpectralIndexOnUnknownLayer()
     {
         var ex = Should.Throw<OgcException>(() => WmsValidator.ValidateStyles(
-            new[] { "NDVI" }, new[] { "missing" }, _ => null));
+            ["NDVI"], ["missing"], _ => null));
         ex.Code.ShouldBe("StyleNotDefined");
     }
 }

--- a/Registry.Web.Test/OrganizationManagerTest.cs
+++ b/Registry.Web.Test/OrganizationManagerTest.cs
@@ -388,12 +388,11 @@ public class OrganizationManagerTest : TestBase
             It.Is<string[]>(slugs => slugs.Length == 3),
             "dest-org",
             ConflictResolutionStrategy.HaltOnConflict))
-            .ReturnsAsync(new[]
-            {
+            .ReturnsAsync([
                 new MoveDatasetResultDto { OriginalSlug = "dataset-0", NewSlug = "dataset-0", Success = true },
                 new MoveDatasetResultDto { OriginalSlug = "dataset-1", NewSlug = "dataset-1", Success = true },
                 new MoveDatasetResultDto { OriginalSlug = "dataset-2", NewSlug = "dataset-2", Success = true }
-            });
+            ]);
 
         // Act
         var result = await _organizationsManager.Merge("source-org", "dest-org");
@@ -428,11 +427,10 @@ public class OrganizationManagerTest : TestBase
             It.IsAny<string[]>(),
             "dest-org",
             ConflictResolutionStrategy.HaltOnConflict))
-            .ReturnsAsync(new[]
-            {
+            .ReturnsAsync([
                 new MoveDatasetResultDto { OriginalSlug = "dataset-0", Success = true },
                 new MoveDatasetResultDto { OriginalSlug = "dataset-1", Success = false, Error = "Conflict detected" }
-            });
+            ]);
 
         // Act
         var result = await _organizationsManager.Merge("source-org", "dest-org");
@@ -456,11 +454,10 @@ public class OrganizationManagerTest : TestBase
             It.IsAny<string[]>(),
             "dest-org",
             ConflictResolutionStrategy.Rename))
-            .ReturnsAsync(new[]
-            {
+            .ReturnsAsync([
                 new MoveDatasetResultDto { OriginalSlug = "dataset-0", NewSlug = "dataset-0_1", Success = true },
                 new MoveDatasetResultDto { OriginalSlug = "dataset-1", NewSlug = "dataset-1", Success = true }
-            });
+            ]);
 
         // Act
         var result = await _organizationsManager.Merge("source-org", "dest-org", ConflictResolutionStrategy.Rename);
@@ -485,11 +482,10 @@ public class OrganizationManagerTest : TestBase
             It.IsAny<string[]>(),
             "dest-org",
             ConflictResolutionStrategy.Overwrite))
-            .ReturnsAsync(new[]
-            {
+            .ReturnsAsync([
                 new MoveDatasetResultDto { OriginalSlug = "dataset-0", NewSlug = "dataset-0", Success = true },
                 new MoveDatasetResultDto { OriginalSlug = "dataset-1", NewSlug = "dataset-1", Success = true }
-            });
+            ]);
 
         // Act
         var result = await _organizationsManager.Merge("source-org", "dest-org", ConflictResolutionStrategy.Overwrite);
@@ -520,10 +516,9 @@ public class OrganizationManagerTest : TestBase
             It.IsAny<string[]>(),
             "dest-org",
             It.IsAny<ConflictResolutionStrategy>()))
-            .ReturnsAsync(new[]
-            {
+            .ReturnsAsync([
                 new MoveDatasetResultDto { OriginalSlug = "dataset-0", NewSlug = "dataset-0", Success = true }
-            });
+            ]);
 
         // Act
         var result = await _organizationsManager.Merge("source-org", "dest-org", deleteSourceOrganization: false);
@@ -671,11 +666,10 @@ public class OrganizationManagerTest : TestBase
             It.IsAny<string[]>(),
             "dest-org",
             It.IsAny<ConflictResolutionStrategy>()))
-            .ReturnsAsync(new[]
-            {
+            .ReturnsAsync([
                 new MoveDatasetResultDto { OriginalSlug = "dataset-0", Success = false, Error = "Error 1" },
                 new MoveDatasetResultDto { OriginalSlug = "dataset-1", Success = false, Error = "Error 2" }
-            });
+            ]);
 
         // Act
         var result = await _organizationsManager.Merge("source-org", "dest-org");

--- a/Registry.Web.Test/ProcessingPlatformTests.cs
+++ b/Registry.Web.Test/ProcessingPlatformTests.cs
@@ -54,11 +54,10 @@ public class ProcessingPlatformTests
     [Test]
     public void Registry_Resolve_ByExactVersion_ReturnsMatch()
     {
-        var registry = new HeavyToolRegistry(new IHeavyTool[]
-        {
+        var registry = new HeavyToolRegistry([
             new FakeTool("build", "1"),
             new FakeTool("build", "2")
-        });
+        ]);
 
         registry.Resolve("build", "1")!.Version.ShouldBe("1");
         registry.Resolve("build", "2")!.Version.ShouldBe("2");
@@ -67,12 +66,11 @@ public class ProcessingPlatformTests
     [Test]
     public void Registry_Resolve_WithoutVersion_PicksHighest()
     {
-        var registry = new HeavyToolRegistry(new IHeavyTool[]
-        {
+        var registry = new HeavyToolRegistry([
             new FakeTool("build", "1"),
             new FakeTool("build", "2"),
             new FakeTool("build", "10")
-        });
+        ]);
 
         registry.Resolve("build")!.Version.ShouldBe("10");
     }
@@ -80,7 +78,7 @@ public class ProcessingPlatformTests
     [Test]
     public void Registry_Resolve_UnknownTool_ReturnsNull()
     {
-        var registry = new HeavyToolRegistry(new IHeavyTool[] { new FakeTool("build", "1") });
+        var registry = new HeavyToolRegistry([new FakeTool("build", "1")]);
 
         registry.Resolve("does-not-exist").ShouldBeNull();
         registry.Resolve("build", "99").ShouldBeNull();
@@ -89,7 +87,7 @@ public class ProcessingPlatformTests
     [Test]
     public void Registry_Resolve_IsCaseInsensitive()
     {
-        var registry = new HeavyToolRegistry(new IHeavyTool[] { new FakeTool("raster-export", "1") });
+        var registry = new HeavyToolRegistry([new FakeTool("raster-export", "1")]);
 
         registry.Resolve("RASTER-EXPORT")!.Id.ShouldBe("raster-export");
     }
@@ -97,21 +95,19 @@ public class ProcessingPlatformTests
     [Test]
     public void Registry_DuplicateRegistration_Throws()
     {
-        Should.Throw<InvalidOperationException>(() => new HeavyToolRegistry(new IHeavyTool[]
-        {
+        Should.Throw<InvalidOperationException>(() => new HeavyToolRegistry([
             new FakeTool("build", "1"),
             new FakeTool("build", "1")
-        }));
+        ]));
     }
 
     [Test]
     public void Registry_All_ExposesEveryTool()
     {
-        var registry = new HeavyToolRegistry(new IHeavyTool[]
-        {
+        var registry = new HeavyToolRegistry([
             new FakeTool("build", "1"),
             new FakeTool("raster-export", "1")
-        });
+        ]);
 
         registry.All.Count.ShouldBe(2);
     }

--- a/Registry.Web.Test/Registry.Web.Test.csproj
+++ b/Registry.Web.Test/Registry.Web.Test.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.3" />
+    <PackageReference Include="Testcontainers" Version="4.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Registry.Web.Test/SystemManagerImportIntegrationTest.cs
+++ b/Registry.Web.Test/SystemManagerImportIntegrationTest.cs
@@ -215,7 +215,7 @@ public class SystemManagerImportIntegrationTest : TestBase
         // Assert
         result.ShouldNotBeNull();
         result.Errors.ShouldBeEmpty($"Import should succeed without errors. Errors: {string.Join(", ", result.Errors.Select(e => e.Message))}");
-        result.FileErrors.ShouldBeEmpty($"File imports should succeed. File errors: {string.Join(", ", result.FileErrors?.Select(e => $"{e.FilePath}: {e.Message}") ?? Array.Empty<string>())}");
+        result.FileErrors.ShouldBeEmpty($"File imports should succeed. File errors: {string.Join(", ", result.FileErrors?.Select(e => $"{e.FilePath}: {e.Message}") ?? [])}");
         result.ImportedItems.Length.ShouldBe(1);
         result.ImportedItems[0].Organization.ShouldBe("imported-org-parallel");
         result.ImportedItems[0].Dataset.ShouldBe("imported-dataset-parallel");

--- a/Registry.Web.Test/SystemManagerTest.cs
+++ b/Registry.Web.Test/SystemManagerTest.cs
@@ -167,10 +167,7 @@ public class SystemManagerTest : TestBase
 
         var ddbMock = new Mock<IDDB>();
         ddbMock.Setup(x => x.RescanIndex("image,geoimage", true))
-            .Returns(new List<RescanResult>
-            {
-                new RescanResult { Path = "image1.jpg", Success = true, Hash = "abc123" }
-            });
+            .Returns([new RescanResult { Path = "image1.jpg", Success = true, Hash = "abc123" }]);
 
         _ddbManagerMock.Setup(x => x.Get(It.IsAny<string>(), It.IsAny<Guid>()))
             .Returns(ddbMock.Object);

--- a/Registry.Web.Test/UsersManagerTest.cs
+++ b/Registry.Web.Test/UsersManagerTest.cs
@@ -55,6 +55,9 @@ public class UsersManagerTest : TestBase
         _httpContextAccessorMock = new Mock<IHttpContextAccessor>();
         _ddbManagerMock = new Mock<IDdbManager>();
         _loginManagerMock = new Mock<ILoginManager>();
+        // ILoginManager.Capabilities has no default implementation; the tests in this fixture exercise
+        // local user management, so default the mock to the local-provider capability set.
+        _loginManagerMock.Setup(x => x.Capabilities).Returns(AuthProviderCapabilities.Local);
         _configurationHelperMock = new Mock<IConfigurationHelper<AppSettings>>();
         _passwordPolicyValidatorMock = new Mock<IPasswordPolicyValidator>();
         _logger = CreateTestLogger<UsersManager>();

--- a/Registry.Web/Controllers/ObjectsController.cs
+++ b/Registry.Web/Controllers/ObjectsController.cs
@@ -1194,7 +1194,7 @@ public class ObjectsController : ControllerBaseEx
             if (string.IsNullOrWhiteSpace(request.ReferencePath))
                 return BadRequest(new ErrorResponse("referencePath is required"));
 
-            var validationError = ValidatePaths(new[] { request.SourcePath, request.ReferencePath });
+            var validationError = ValidatePaths([request.SourcePath, request.ReferencePath]);
             if (validationError != null) return validationError;
 
             var json = await _objectsManager.ValidateAlignRaster(orgSlug, dsSlug,

--- a/Registry.Web/Controllers/SystemController.cs
+++ b/Registry.Web/Controllers/SystemController.cs
@@ -38,6 +38,7 @@ public class SystemController : ControllerBaseEx
     private readonly IHeavyToolRegistry _toolRegistry;
     private readonly ILogger<SystemController> _logger;
     private readonly AppSettings _appSettings;
+    private readonly ILoginManager _loginManager;
 
     public SystemController(
         ISystemManager systemManager,
@@ -46,7 +47,8 @@ public class SystemController : ControllerBaseEx
         IDdbWrapper ddbWrapper,
         IHeavyToolRegistry toolRegistry,
         ILogger<SystemController> logger,
-        IOptions<AppSettings> appSettings)
+        IOptions<AppSettings> appSettings,
+        ILoginManager loginManager)
     {
         _systemManager = systemManager;
         _datasetsManager = datasetsManager;
@@ -55,6 +57,7 @@ public class SystemController : ControllerBaseEx
         _toolRegistry = toolRegistry;
         _logger = logger;
         _appSettings = appSettings.Value;
+        _loginManager = loginManager;
     }
 
     /// <summary>
@@ -413,7 +416,9 @@ public class SystemController : ControllerBaseEx
         var features = new FeaturesDto
         {
             OrganizationMemberManagement = _appSettings.EnableOrganizationMemberManagement,
-            UserManagement = string.IsNullOrWhiteSpace(_appSettings.ExternalAuthUrl),
+            // Derived from the active provider's capability so that LDAP, Remote,
+            // and any future external provider all produce false automatically.
+            UserManagement = _loginManager.Capabilities.SupportsLocalUserManagement,
             StorageLimiter = _appSettings.EnableStorageLimiter,
             MaxConcurrentDownloadsPerUser = _appSettings.MaxConcurrentDownloadsPerUser,
             DisableAnonymousBulkDownloads = _appSettings.DisableAnonymousBulkDownloads,

--- a/Registry.Web/HealthChecks/LdapHealthCheck.cs
+++ b/Registry.Web/HealthChecks/LdapHealthCheck.cs
@@ -1,0 +1,68 @@
+using System;
+using System.DirectoryServices.Protocols;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Registry.Web.Models.Configuration;
+
+namespace Registry.Web.HealthChecks;
+
+/// <summary>
+/// Verifies connectivity to the configured LDAP server by attempting a bind
+/// with the service account (or an anonymous bind if no account is configured).
+/// Registered only when <see cref="LdapSettings.Enabled"/> is true.
+/// </summary>
+public class LdapHealthCheck : IHealthCheck
+{
+    private readonly LdapSettings _settings;
+
+    public LdapHealthCheck(IOptions<AppSettings> appSettings)
+    {
+        _settings = appSettings.Value.LdapSettings;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        if (_settings?.Enabled != true)
+            return Task.FromResult(HealthCheckResult.Healthy("LDAP authentication is disabled"));
+
+        try
+        {
+            var identifier = new LdapDirectoryIdentifier(
+                _settings.Server, _settings.Port, false, false);
+
+            using var conn = new LdapConnection(identifier)
+            {
+                AuthType = AuthType.Basic,
+                Timeout = TimeSpan.FromSeconds(_settings.Timeout)
+            };
+
+            conn.SessionOptions.ProtocolVersion = 3;
+
+            if (_settings.UseSsl)
+            {
+                conn.SessionOptions.SecureSocketLayer = true;
+                if (!_settings.ValidateSslCertificate)
+                    conn.SessionOptions.VerifyServerCertificate = (_, _) => true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(_settings.BindDn))
+                conn.Bind(new NetworkCredential(_settings.BindDn, _settings.BindPassword));
+            else
+                conn.Bind(); // anonymous bind - tests TCP connectivity
+
+            return Task.FromResult(
+                HealthCheckResult.Healthy(
+                    $"LDAP server {_settings.Server}:{_settings.Port} is reachable"));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(
+                HealthCheckResult.Unhealthy(
+                    $"LDAP server {_settings.Server}:{_settings.Port} is not reachable: {ex.Message}", ex));
+        }
+    }
+}

--- a/Registry.Web/HealthChecks/LdapHealthCheck.cs
+++ b/Registry.Web/HealthChecks/LdapHealthCheck.cs
@@ -50,9 +50,28 @@ public class LdapHealthCheck : IHealthCheck
             }
 
             if (!string.IsNullOrWhiteSpace(_settings.BindDn))
+            {
                 conn.Bind(new NetworkCredential(_settings.BindDn, _settings.BindPassword));
-            else
+
+                return Task.FromResult(
+                    HealthCheckResult.Healthy(
+                        $"LDAP server {_settings.Server}:{_settings.Port} is reachable and the service bind succeeded"));
+            }
+
+            // No service account configured: attempt an anonymous bind. Many LDAP/AD servers reject
+            // anonymous binds by policy even though they are perfectly reachable, so a rejected bind
+            // is reported as Degraded (reachable but not validated) rather than Unhealthy.
+            try
+            {
                 conn.Bind(); // anonymous bind - tests TCP connectivity
+            }
+            catch (LdapException ex) when (!IsConnectivityError(ex.ErrorCode))
+            {
+                return Task.FromResult(
+                    HealthCheckResult.Degraded(
+                        $"LDAP server {_settings.Server}:{_settings.Port} is reachable but the anonymous bind was " +
+                        $"rejected ({ex.Message}). Configure BindDn to fully validate connectivity."));
+            }
 
             return Task.FromResult(
                 HealthCheckResult.Healthy(
@@ -65,4 +84,13 @@ public class LdapHealthCheck : IHealthCheck
                     $"LDAP server {_settings.Server}:{_settings.Port} is not reachable: {ex.Message}", ex));
         }
     }
+
+    /// <summary>
+    /// Returns true for LDAP error codes that indicate the server could not be reached
+    /// (as opposed to the server being reachable but rejecting the bind).
+    /// </summary>
+    private static bool IsConnectivityError(int errorCode) =>
+        errorCode is 81  // LDAP_SERVER_DOWN
+                  or 85  // LDAP_TIMEOUT
+                  or 91; // LDAP_CONNECT_ERROR
 }

--- a/Registry.Web/HealthChecks/UserManagerHealthCheck.cs
+++ b/Registry.Web/HealthChecks/UserManagerHealthCheck.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Registry.Web.Identity.Models;
 using Registry.Web.Models;
+using Registry.Web.Services.Ports;
 using Registry.Web.Utilities;
 
 namespace Registry.Web.HealthChecks;
@@ -14,13 +15,22 @@ namespace Registry.Web.HealthChecks;
 public class UserManagerHealthCheck : IHealthCheck
 {
     private readonly UserManager<User> _userManager;
-    public UserManagerHealthCheck(UserManager<User> userManager)
+    private readonly ILoginManager _loginManager;
+
+    public UserManagerHealthCheck(UserManager<User> userManager, ILoginManager loginManager)
     {
         _userManager = userManager;
+        _loginManager = loginManager;
     }
 
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
     {
+        // CAMBIO DI COMPORTAMENTO (deliberato): skip local user-manager test when an external
+        // identity provider is active. The test would only verify the local store, not the
+        // actual authentication path. A dedicated provider health check is registered instead.
+        if (!_loginManager.Capabilities.SupportsLocalUserManagement)
+            return HealthCheckResult.Healthy(
+                "Skipped: user management is handled by an external identity provider");
 
         var testUserName = "test-" + Guid.NewGuid();
         var testPassword = Guid.NewGuid().ToString() + Guid.NewGuid().ToString().ToUpperInvariant() + "_&%$";

--- a/Registry.Web/HealthChecks/UserManagerHealthCheck.cs
+++ b/Registry.Web/HealthChecks/UserManagerHealthCheck.cs
@@ -25,7 +25,7 @@ public class UserManagerHealthCheck : IHealthCheck
 
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
     {
-        // CAMBIO DI COMPORTAMENTO (deliberato): skip local user-manager test when an external
+        // BEHAVIOR CHANGE (deliberate): skip local user-manager test when an external
         // identity provider is active. The test would only verify the local store, not the
         // actual authentication path. A dedicated provider health check is registered instead.
         if (!_loginManager.Capabilities.SupportsLocalUserManagement)

--- a/Registry.Web/Models/Configuration/AppSettings.cs
+++ b/Registry.Web/Models/Configuration/AppSettings.cs
@@ -96,6 +96,12 @@ public class AppSettings
     public string ExternalAuthUrl { get; set; }
 
     /// <summary>
+    /// LDAP/Active Directory authentication settings.
+    /// Mutually exclusive with <see cref="ExternalAuthUrl"/>.
+    /// </summary>
+    public LdapSettings LdapSettings { get; set; }
+
+    /// <summary>
     /// Cache provider settings
     /// </summary>
     public CacheProvider CacheProvider { get; set; }

--- a/Registry.Web/Models/Configuration/LdapSettings.cs
+++ b/Registry.Web/Models/Configuration/LdapSettings.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace Registry.Web.Models.Configuration;
+
+public class LdapSettings
+{
+    /// <summary>Enables LDAP/Active Directory authentication.</summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>LDAP server host (e.g. "ldap.example.com" or "dc.domain.com").</summary>
+    public string Server { get; set; }
+
+    /// <summary>LDAP port. 389 for plain LDAP, 636 for LDAPS.</summary>
+    public int Port { get; set; } = 636;
+
+    /// <summary>Use SSL/TLS (LDAPS). Strongly recommended in production.</summary>
+    public bool UseSsl { get; set; } = true;
+
+    /// <summary>
+    /// Validate the server SSL certificate chain.
+    /// Set to false only for local testing with self-signed certificates.
+    /// </summary>
+    public bool ValidateSslCertificate { get; set; } = true;
+
+    /// <summary>
+    /// Base DN for searches (e.g. "dc=example,dc=com").
+    /// Required.
+    /// </summary>
+    public string BaseDn { get; set; }
+
+    /// <summary>
+    /// Service account DN used for the initial search bind.
+    /// If null, an anonymous bind is attempted.
+    /// </summary>
+    public string BindDn { get; set; }
+
+    /// <summary>
+    /// Password for <see cref="BindDn"/>.
+    /// Never commit in plain text - use environment variables or secrets management.
+    /// </summary>
+    public string BindPassword { get; set; }
+
+    /// <summary>
+    /// LDAP search filter to locate the user entry.
+    /// <c>{0}</c> is replaced with the (escaped) username.
+    /// AD default: <c>(sAMAccountName={0})</c>.
+    /// OpenLDAP default: <c>(uid={0})</c>.
+    /// </summary>
+    public string SearchFilter { get; set; } = "(sAMAccountName={0})";
+
+    /// <summary>
+    /// Optional format string for constructing the user principal directly (bypasses the search step).
+    /// <c>{0}</c> is replaced with the username.
+    /// Examples: <c>{0}@domain.com</c> (UPN) or <c>CN={0},OU=Users,DC=domain,DC=com</c>.
+    /// </summary>
+    public string UserDnFormat { get; set; }
+
+    /// <summary>
+    /// Distinguished names of LDAP groups whose members receive the Registry admin role.
+    /// Comparison is case-insensitive.
+    /// </summary>
+    public string[] AdminGroupDns { get; set; } = Array.Empty<string>();
+
+    /// <summary>LDAP attribute for the user email address. AD default: <c>mail</c>.</summary>
+    public string EmailAttribute { get; set; } = "mail";
+
+    /// <summary>LDAP attribute for the display name. AD default: <c>displayName</c>.</summary>
+    public string DisplayNameAttribute { get; set; } = "displayName";
+
+    /// <summary>LDAP attribute listing group memberships. Default: <c>memberOf</c>.</summary>
+    public string GroupMembershipAttribute { get; set; } = "memberOf";
+
+    /// <summary>Timeout in seconds for LDAP operations.</summary>
+    public int Timeout { get; set; } = 30;
+}

--- a/Registry.Web/Models/Configuration/LdapSettings.cs
+++ b/Registry.Web/Models/Configuration/LdapSettings.cs
@@ -59,7 +59,7 @@ public class LdapSettings
     /// Distinguished names of LDAP groups whose members receive the Registry admin role.
     /// Comparison is case-insensitive.
     /// </summary>
-    public string[] AdminGroupDns { get; set; } = Array.Empty<string>();
+    public string[] AdminGroupDns { get; set; } = [];
 
     /// <summary>LDAP attribute for the user email address. AD default: <c>mail</c>.</summary>
     public string EmailAttribute { get; set; } = "mail";

--- a/Registry.Web/Models/Configuration/ProcessingPlatformSettings.cs
+++ b/Registry.Web/Models/Configuration/ProcessingPlatformSettings.cs
@@ -65,7 +65,7 @@ public class ProcessingPlatformSettings
     /// NodeODM processing nodes available for the <c>photogrammetry</c> tool.
     /// Config-based registry (no DB table) for the reduced-scope integration.
     /// </summary>
-    public List<NodeOdmNodeConfig> NodeOdm { get; set; } = new();
+    public List<NodeOdmNodeConfig> NodeOdm { get; set; } = [];
 }
 
 /// <summary>

--- a/Registry.Web/Program.cs
+++ b/Registry.Web/Program.cs
@@ -883,6 +883,27 @@ public class Program
                 Console.WriteLine(" !> ClearCacheInterval is not valid (must be at least 1 minute)");
                 return false;
             }
+
+            if (settings.LdapSettings?.Enabled == true)
+            {
+                if (!string.IsNullOrWhiteSpace(settings.ExternalAuthUrl))
+                {
+                    Console.WriteLine(" !> Cannot enable both LDAP and External authentication simultaneously");
+                    return false;
+                }
+
+                if (string.IsNullOrWhiteSpace(settings.LdapSettings.Server))
+                {
+                    Console.WriteLine(" !> LdapSettings.Server is required when LDAP is enabled");
+                    return false;
+                }
+
+                if (string.IsNullOrWhiteSpace(settings.LdapSettings.BaseDn))
+                {
+                    Console.WriteLine(" !> LdapSettings.BaseDn is required when LDAP is enabled");
+                    return false;
+                }
+            }
         }
         catch (Exception ex)
         {

--- a/Registry.Web/Program.cs
+++ b/Registry.Web/Program.cs
@@ -471,10 +471,30 @@ public class Program
         switch (parts.Length)
         {
             case 1:
-            {
-                if (!int.TryParse(parts[0], out port))
                 {
-                    // Try to parse as hostname
+                    if (!int.TryParse(parts[0], out port))
+                    {
+                        // Try to parse as hostname
+                        host = parts[0];
+
+                        if (!host.Equals("localhost", StringComparison.InvariantCultureIgnoreCase) &&
+                            !IPEndPoint.TryParse(host, out _))
+                        {
+                            CommonUtils.WriteColor(" !> Invalid address", ConsoleColor.Red);
+                            return false;
+                        }
+                    }
+
+                    if (port is < 1 or > 65535)
+                    {
+                        CommonUtils.WriteColor(" !> Invalid port", ConsoleColor.Red);
+                        return false;
+                    }
+
+                    break;
+                }
+            case 2:
+                {
                     host = parts[0];
 
                     if (!host.Equals("localhost", StringComparison.InvariantCultureIgnoreCase) &&
@@ -483,41 +503,21 @@ public class Program
                         CommonUtils.WriteColor(" !> Invalid address", ConsoleColor.Red);
                         return false;
                     }
+
+                    if (!int.TryParse(parts[1], out port))
+                    {
+                        CommonUtils.WriteColor(" !> Invalid port", ConsoleColor.Red);
+                        return false;
+                    }
+
+                    if (port is < 1 or > 65535)
+                    {
+                        CommonUtils.WriteColor(" !> Invalid port", ConsoleColor.Red);
+                        return false;
+                    }
+
+                    break;
                 }
-
-                if (port is < 1 or > 65535)
-                {
-                    CommonUtils.WriteColor(" !> Invalid port", ConsoleColor.Red);
-                    return false;
-                }
-
-                break;
-            }
-            case 2:
-            {
-                host = parts[0];
-
-                if (!host.Equals("localhost", StringComparison.InvariantCultureIgnoreCase) &&
-                    !IPEndPoint.TryParse(host, out _))
-                {
-                    CommonUtils.WriteColor(" !> Invalid address", ConsoleColor.Red);
-                    return false;
-                }
-
-                if (!int.TryParse(parts[1], out port))
-                {
-                    CommonUtils.WriteColor(" !> Invalid port", ConsoleColor.Red);
-                    return false;
-                }
-
-                if (port is < 1 or > 65535)
-                {
-                    CommonUtils.WriteColor(" !> Invalid port", ConsoleColor.Red);
-                    return false;
-                }
-
-                break;
-            }
             default:
                 CommonUtils.WriteColor(" !> Invalid address", ConsoleColor.Red);
                 return false;
@@ -901,6 +901,13 @@ public class Program
                 if (string.IsNullOrWhiteSpace(settings.LdapSettings.BaseDn))
                 {
                     Console.WriteLine(" !> LdapSettings.BaseDn is required when LDAP is enabled");
+                    return false;
+                }
+
+                if (string.IsNullOrWhiteSpace(settings.LdapSettings.SearchFilter) ||
+                     !settings.LdapSettings.SearchFilter.Contains("{0}", StringComparison.Ordinal))
+                {
+                    Console.WriteLine(" !> LdapSettings.SearchFilter must contain the '{0}' placeholder for the username");
                     return false;
                 }
             }

--- a/Registry.Web/Registry.Web.csproj
+++ b/Registry.Web/Registry.Web.csproj
@@ -78,6 +78,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Scrutor" Version="7.0.0" />
         <PackageReference Include="Scrutor.AspNetCore" Version="3.3.0" />
+        <PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
         <PackageReference Include="Serilog.Aspnetcore.Middleware" Version="1.0.0" />
         <PackageReference Include="Serilog.Enrichers.AspNetCore" Version="1.0.0" />

--- a/Registry.Web/Services/HeavyTasks/Adapters/HeavyToolRegistry.cs
+++ b/Registry.Web/Services/HeavyTasks/Adapters/HeavyToolRegistry.cs
@@ -17,7 +17,7 @@ public sealed class HeavyToolRegistry : IHeavyToolRegistry
     private readonly Dictionary<string, Dictionary<string, IHeavyTool>> _byId =
         new(StringComparer.OrdinalIgnoreCase);
 
-    private readonly List<IHeavyTool> _all = new();
+    private readonly List<IHeavyTool> _all = [];
 
     public HeavyToolRegistry(IEnumerable<IHeavyTool> tools)
     {

--- a/Registry.Web/Services/HeavyTasks/Adapters/LogRingBuffer.cs
+++ b/Registry.Web/Services/HeavyTasks/Adapters/LogRingBuffer.cs
@@ -24,7 +24,7 @@ public sealed class LogLine
 /// </summary>
 public sealed class LogTailSnapshot
 {
-    [JsonPropertyName("lines")] public List<LogLine> Lines { get; set; } = new();
+    [JsonPropertyName("lines")] public List<LogLine> Lines { get; set; } = [];
     [JsonPropertyName("cursor")] public long Cursor { get; set; }
     [JsonPropertyName("truncatedFromTail")] public long TruncatedFromTail { get; set; }
 }
@@ -40,7 +40,7 @@ public sealed class LogRingBuffer
 {
     private readonly int _maxLines;
     private readonly int _maxBytes;
-    private readonly LinkedList<LogLine> _lines = new();
+    private readonly LinkedList<LogLine> _lines = [];
     private long _byteCount;
     private long _cursor;
     private long _truncatedFromTail;
@@ -88,7 +88,7 @@ public sealed class LogRingBuffer
     /// <summary>Produces a serializable snapshot of the current buffer state.</summary>
     public LogTailSnapshot Snapshot() => new()
     {
-        Lines = new List<LogLine>(_lines),
+        Lines = [.._lines],
         Cursor = _cursor,
         TruncatedFromTail = _truncatedFromTail
     };

--- a/Registry.Web/Services/HeavyTasks/NodeOdm/NodeOdmClient.cs
+++ b/Registry.Web/Services/HeavyTasks/NodeOdm/NodeOdmClient.cs
@@ -236,7 +236,7 @@ public sealed class NodeOdmClient : INodeOdmClient
     {
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
-        if (root.ValueKind != JsonValueKind.Array) return Array.Empty<string>();
+        if (root.ValueKind != JsonValueKind.Array) return [];
 
         var lines = new List<string>(root.GetArrayLength());
         foreach (var el in root.EnumerateArray())

--- a/Registry.Web/Services/HeavyTasks/NodeOdm/NodeOdmNodeRegistry.cs
+++ b/Registry.Web/Services/HeavyTasks/NodeOdm/NodeOdmNodeRegistry.cs
@@ -18,7 +18,7 @@ public sealed class NodeOdmNodeRegistry : INodeOdmNodeRegistry
 
     public NodeOdmNodeRegistry(IOptions<AppSettings> appSettings)
     {
-        var configured = appSettings.Value.ProcessingPlatform?.NodeOdm ?? new List<NodeOdmNodeConfig>();
+        var configured = appSettings.Value.ProcessingPlatform?.NodeOdm ?? [];
 
         _nodes = configured
             .Where(c => !string.IsNullOrWhiteSpace(c.Url))

--- a/Registry.Web/Services/Initialization/DatabaseInitializer.cs
+++ b/Registry.Web/Services/Initialization/DatabaseInitializer.cs
@@ -127,7 +127,7 @@ internal class DatabaseInitializer
     {
         var loginManager = _services.GetRequiredService<ILoginManager>();
 
-        // CAMBIO DI COMPORTAMENTO (deliberato): when an external identity provider is active
+        // BEHAVIOR CHANGE (deliberate): when an external identity provider is active
         // (LDAP or Remote), skip creating a local default admin. Admin privileges are granted
         // via the provider's group mapping instead. This change also affects Remote mode.
         if (!loginManager.Capabilities.SupportsLocalUserManagement)

--- a/Registry.Web/Services/Initialization/DatabaseInitializer.cs
+++ b/Registry.Web/Services/Initialization/DatabaseInitializer.cs
@@ -15,6 +15,7 @@ using Registry.Web.Data.Models;
 using Registry.Web.Identity;
 using Registry.Web.Identity.Models;
 using Registry.Web.Models.Configuration;
+using Registry.Web.Services.Ports;
 using Registry.Web.Utilities;
 
 namespace Registry.Web.Services.Initialization;
@@ -124,6 +125,19 @@ internal class DatabaseInitializer
 
     private async Task CreateDefaultAdminAsync(CancellationToken token)
     {
+        var loginManager = _services.GetRequiredService<ILoginManager>();
+
+        // CAMBIO DI COMPORTAMENTO (deliberato): when an external identity provider is active
+        // (LDAP or Remote), skip creating a local default admin. Admin privileges are granted
+        // via the provider's group mapping instead. This change also affects Remote mode.
+        if (!loginManager.Capabilities.SupportsLocalUserManagement)
+        {
+            _logger.LogInformation(
+                "Default admin creation skipped: identity is managed by an external provider. " +
+                "Admin privileges are assigned via the provider's group/role mapping.");
+            return;
+        }
+
         var userManager = _services.GetRequiredService<UserManager<User>>();
         var roleManager = _services.GetRequiredService<RoleManager<IdentityRole>>();
         var appSettings = _services.GetRequiredService<IOptions<AppSettings>>().Value;

--- a/Registry.Web/Services/Managers/LdapLoginManager.cs
+++ b/Registry.Web/Services/Managers/LdapLoginManager.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.DirectoryServices.Protocols;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Registry.Web.Identity;
+using Registry.Web.Models.Configuration;
+using Registry.Web.Models.DTO;
+using Registry.Web.Services.Ports;
+
+namespace Registry.Web.Services.Managers;
+
+/// <summary>
+/// Authenticates users against an LDAP or Active Directory server.
+/// Implements the <see cref="ILoginManager"/> contract; all Registry authorization
+/// and user-lifecycle concerns are handled upstream in <c>UsersManager</c>.
+/// </summary>
+public class LdapLoginManager : ILoginManager
+{
+    private readonly ILogger<LdapLoginManager> _logger;
+    private readonly LdapSettings _settings;
+
+    public LdapLoginManager(ILogger<LdapLoginManager> logger, IOptions<AppSettings> appSettings)
+    {
+        _logger = logger;
+        _settings = appSettings.Value.LdapSettings
+            ?? throw new InvalidOperationException(
+                "LdapSettings must be configured in appsettings.json when LDAP authentication is enabled.");
+    }
+
+    /// <inheritdoc />
+    public AuthProviderCapabilities Capabilities => AuthProviderCapabilities.External;
+
+    /// <inheritdoc />
+    public Task<LoginResultDto> CheckAccess(string token)
+    {
+        // LDAP does not support token-based authentication
+        return Task.FromResult(new LoginResultDto { Success = false });
+    }
+
+    /// <inheritdoc />
+    public Task<LoginResultDto> CheckAccess(string userName, string password)
+    {
+        if (string.IsNullOrWhiteSpace(userName) || string.IsNullOrWhiteSpace(password))
+            return Task.FromResult(new LoginResultDto { Success = false, UserName = userName });
+
+        var safeUserName = EscapeLdapFilter(userName);
+
+        try
+        {
+            string userEmail;
+            string displayName;
+            List<string> memberOf;
+
+            if (!string.IsNullOrWhiteSpace(_settings.UserDnFormat))
+            {
+                // Path A: direct bind using UserDnFormat (e.g. UPN: "{0}@domain.com")
+                // The username is not DN-escaped here; UPN and similar formats do not use DN syntax.
+                var userPrincipal = string.Format(_settings.UserDnFormat, userName);
+
+                using var conn = CreateConnection();
+                conn.Bind(new NetworkCredential(userPrincipal, password));
+
+                // Retrieve attributes via the authenticated user's own credentials
+                (userEmail, displayName, memberOf) = FetchUserAttributes(conn, safeUserName);
+            }
+            else
+            {
+                // Path B: service account search to locate the user DN, then user bind to verify password
+                string userDn;
+
+                using (var svcConn = CreateConnection())
+                {
+                    if (!string.IsNullOrWhiteSpace(_settings.BindDn))
+                        svcConn.Bind(new NetworkCredential(_settings.BindDn, _settings.BindPassword));
+                    else
+                        svcConn.Bind(); // anonymous bind
+
+                    (userDn, userEmail, displayName, memberOf) = SearchUser(svcConn, safeUserName);
+                }
+
+                if (userDn == null)
+                {
+                    _logger.LogInformation(
+                        "LDAP authentication failed: user {UserName} not found in directory", userName);
+                    return Task.FromResult(new LoginResultDto { Success = false, UserName = userName });
+                }
+
+                // Verify the user's password by attempting a bind as the user
+                using var userConn = CreateConnection();
+                userConn.Bind(new NetworkCredential(userDn, password));
+            }
+
+            var isAdmin = IsAdminGroupMember(memberOf);
+            var roles = isAdmin
+                ? new[] { ApplicationDbContext.AdminRoleName }
+                : Array.Empty<string>();
+
+            _logger.LogInformation(
+                "LDAP authentication successful for user {UserName} (admin: {IsAdmin})", userName, isAdmin);
+
+            return Task.FromResult(new LoginResultDto
+            {
+                Success = true,
+                UserName = userName,
+                Metadata = new Dictionary<string, object>
+                {
+                    ["email"] = userEmail ?? string.Empty,
+                    ["displayName"] = displayName ?? userName,
+                    ["roles"] = roles,
+                    ["authProvider"] = "ldap"
+                }
+            });
+        }
+        catch (LdapException ex) when (ex.ErrorCode == 49) // InvalidCredentials
+        {
+            _logger.LogInformation(
+                "LDAP authentication failed for user {UserName}: invalid credentials", userName);
+            return Task.FromResult(new LoginResultDto { Success = false, UserName = userName });
+        }
+        catch (LdapException ex)
+        {
+            _logger.LogError(ex,
+                "LDAP error (code {ErrorCode}) during authentication for user {UserName}", ex.ErrorCode, userName);
+            return Task.FromResult(new LoginResultDto { Success = false, UserName = userName });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during LDAP authentication for user {UserName}", userName);
+            return Task.FromResult(new LoginResultDto { Success = false, UserName = userName });
+        }
+    }
+
+    /// <summary>Creates a configured <see cref="LdapConnection"/> for this provider's settings.</summary>
+    internal LdapConnection CreateConnection()
+    {
+        var identifier = new LdapDirectoryIdentifier(_settings.Server, _settings.Port, false, false);
+        var conn = new LdapConnection(identifier)
+        {
+            AuthType = AuthType.Basic,
+            Timeout = TimeSpan.FromSeconds(_settings.Timeout)
+        };
+
+        conn.SessionOptions.ProtocolVersion = 3;
+
+        if (_settings.UseSsl)
+        {
+            conn.SessionOptions.SecureSocketLayer = true;
+
+            if (!_settings.ValidateSslCertificate)
+                conn.SessionOptions.VerifyServerCertificate = (_, _) => true;
+        }
+
+        return conn;
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private (string dn, string email, string displayName, List<string> groups) SearchUser(
+        LdapConnection conn, string safeUserName)
+    {
+        var filter = string.Format(_settings.SearchFilter, safeUserName);
+        var attrs = new[]
+        {
+            _settings.EmailAttribute,
+            _settings.DisplayNameAttribute,
+            _settings.GroupMembershipAttribute
+        };
+
+        var request = new SearchRequest(_settings.BaseDn, filter, SearchScope.Subtree, attrs)
+        {
+            SizeLimit = 1,
+            TimeLimit = TimeSpan.FromSeconds(_settings.Timeout)
+        };
+
+        var response = (SearchResponse)conn.SendRequest(request);
+
+        if (response.Entries.Count == 0)
+            return (null, null, null, []);
+
+        var entry = response.Entries[0];
+        return (
+            entry.DistinguishedName,
+            GetAttribute(entry, _settings.EmailAttribute),
+            GetAttribute(entry, _settings.DisplayNameAttribute),
+            GetMultiValueAttribute(entry, _settings.GroupMembershipAttribute)
+        );
+    }
+
+    private (string email, string displayName, List<string> groups) FetchUserAttributes(
+        LdapConnection conn, string safeUserName)
+    {
+        var (_, email, displayName, groups) = SearchUser(conn, safeUserName);
+        return (email, displayName, groups);
+    }
+
+    private bool IsAdminGroupMember(List<string> memberOf)
+    {
+        if (_settings.AdminGroupDns == null || _settings.AdminGroupDns.Length == 0 || memberOf == null)
+            return false;
+
+        foreach (var group in memberOf)
+            foreach (var adminDn in _settings.AdminGroupDns)
+                if (string.Equals(group, adminDn, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+        return false;
+    }
+
+    private static string GetAttribute(SearchResultEntry entry, string attributeName)
+    {
+        if (string.IsNullOrEmpty(attributeName) || !entry.Attributes.Contains(attributeName))
+            return null;
+
+        var values = entry.Attributes[attributeName].GetValues(typeof(string));
+        return values.Length > 0 ? values[0] as string : null;
+    }
+
+    private static List<string> GetMultiValueAttribute(SearchResultEntry entry, string attributeName)
+    {
+        if (string.IsNullOrEmpty(attributeName) || !entry.Attributes.Contains(attributeName))
+            return [];
+
+        var values = entry.Attributes[attributeName].GetValues(typeof(string));
+        var result = new List<string>(values.Length);
+        foreach (var v in values)
+            if (v is string s)
+                result.Add(s);
+        return result;
+    }
+
+    /// <summary>
+    /// Escapes special characters in an LDAP search filter value per RFC 4515.
+    /// Must be applied to any user-supplied string inserted into a filter expression.
+    /// </summary>
+    private static string EscapeLdapFilter(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return string.Empty;
+
+        return input
+            .Replace("\\", "\\5c")
+            .Replace("*", "\\2a")
+            .Replace("(", "\\28")
+            .Replace(")", "\\29")
+            .Replace("\0", "\\00");
+    }
+}

--- a/Registry.Web/Services/Managers/LocalLoginManager.cs
+++ b/Registry.Web/Services/Managers/LocalLoginManager.cs
@@ -28,6 +28,8 @@ public class LocalLoginManager : ILoginManager
         _settings = settings.Value;
     }
 
+    public AuthProviderCapabilities Capabilities => AuthProviderCapabilities.Local;
+
     public Task<LoginResultDto> CheckAccess(string token)
     {
         // No token login for local auth

--- a/Registry.Web/Services/Managers/RemoteLoginManager.cs
+++ b/Registry.Web/Services/Managers/RemoteLoginManager.cs
@@ -27,6 +27,8 @@ public class RemoteLoginManager : ILoginManager
         _httpClientFactory = httpClientFactory;
     }
 
+    public AuthProviderCapabilities Capabilities => AuthProviderCapabilities.External;
+
     public async Task<LoginResultDto> CheckAccess(string token)
     {
 

--- a/Registry.Web/Services/Managers/StacManager.cs
+++ b/Registry.Web/Services/Managers/StacManager.cs
@@ -39,7 +39,7 @@ public class StacManager : IStacManager
 
     // STAC API 1.0.0 conformance classes implemented by this server
     private static readonly string[] ConformanceClasses =
-    {
+    [
         "https://api.stacspec.org/v1.0.0/core",
         "https://api.stacspec.org/v1.0.0/collections",
         "https://api.stacspec.org/v1.0.0/ogcapi-features",
@@ -47,7 +47,7 @@ public class StacManager : IStacManager
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"
-    };
+    ];
 
     private const int DefaultLimit = 10;
     private const int MaxLimit = 10000;
@@ -272,7 +272,7 @@ public class StacManager : IStacManager
                 bboxStr, datetime, lim, off) is not JObject result)
             throw new InvalidOperationException("Invalid STAC item collection result");
 
-        var features = result["features"] as JArray ?? new JArray();
+        var features = result["features"] as JArray ?? [];
         foreach (var feature in features.OfType<JObject>())
             RewriteItem(feature, orgSlug, dsSlug, collectionId);
 
@@ -362,7 +362,7 @@ public class StacManager : IStacManager
                     bboxStr, datetime, need, off) is not JObject fc)
                 continue;
 
-            var feats = fc["features"] as JArray ?? new JArray();
+            var feats = fc["features"] as JArray ?? [];
             var matched = fc["numberMatched"]?.Value<long>() ?? feats.Count;
 
             foreach (var feature in feats.OfType<JObject>())
@@ -428,7 +428,7 @@ public class StacManager : IStacManager
                     bboxStr, datetime, MaxLimit, 0) is not JObject fc)
                 continue;
 
-            var feats = fc["features"] as JArray ?? new JArray();
+            var feats = fc["features"] as JArray ?? [];
             foreach (var feature in feats.OfType<JObject>())
             {
                 RewriteItem(feature, ds.Organization.Slug, ds.Slug, collectionId);
@@ -548,7 +548,7 @@ public class StacManager : IStacManager
         double[] flat = bbox switch
         {
             { Length: 4 } => bbox,
-            { Length: 6 } => new[] { bbox[0], bbox[1], bbox[3], bbox[4] },
+            { Length: 6 } => [bbox[0], bbox[1], bbox[3], bbox[4]],
             _ => null
         };
 

--- a/Registry.Web/Services/Managers/UsersManager.cs
+++ b/Registry.Web/Services/Managers/UsersManager.cs
@@ -68,6 +68,19 @@ public class UsersManager : IUsersManager
         _appSettings = appSettings.Value;
     }
 
+    /// <summary>Shorthand accessor for the active provider's capability descriptor.</summary>
+    private AuthProviderCapabilities Caps => _loginManager.Capabilities;
+
+    /// <summary>
+    /// Generates an internal password for users managed by an external identity provider.
+    /// The password is never used for authentication (auth is always delegated to the provider),
+    /// but ASP.NET Core Identity requires a hashed credential record in the local DB.
+    /// The generated string satisfies any common Identity password policy:
+    /// upper, lower, digit, non-alphanumeric, length >= 32.
+    /// </summary>
+    private static string GenerateExternalUserPassword()
+        => "!" + CommonUtils.RandomString(29) + "Aa1";
+
     public async Task<AuthenticateResponse> Authenticate(string userName, string password)
     {
         var res = await _loginManager.CheckAccess(userName, password);
@@ -75,9 +88,15 @@ public class UsersManager : IUsersManager
         if (!res.Success)
             return null;
 
-        // Create user if not exists because login manager has greenlighed us
-        var user = await _userManager.FindByNameAsync(userName) ??
-                   await CreateUserInternal(new User { UserName = userName }, password);
+        // Create user if not exists because login manager has greenlit us.
+        // For external providers (LDAP, Remote) store a random internal password that is never
+        // used for authentication - the provider handles all credential verification.
+        var user = await _userManager.FindByNameAsync(userName);
+        if (user == null)
+        {
+            var localPassword = Caps.SupportsPasswordChange ? password : GenerateExternalUserPassword();
+            user = await CreateUserInternal(new User { UserName = userName }, localPassword);
+        }
 
         if (!user.Metadata.IsSameAs(res.Metadata))
         {
@@ -161,6 +180,11 @@ public class UsersManager : IUsersManager
     {
         if (!await _authManager.IsUserAdmin())
             throw new UnauthorizedException("Only admins can create new users");
+
+        if (!Caps.SupportsLocalUserManagement)
+            throw new InvalidOperationException(
+                "Manual user creation is disabled. Users are provisioned automatically on their first login " +
+                "via the configured identity provider.");
 
         if (!IsValidUserName(userName))
             throw new ArgumentException("The provided username is not valid");
@@ -292,6 +316,11 @@ public class UsersManager : IUsersManager
     private async Task<ChangePasswordResult> ChangePasswordInternal(User user, string currentPassword,
         string newPassword)
     {
+        if (!Caps.SupportsPasswordChange)
+            throw new InvalidOperationException(
+                "Password changes are not supported for accounts managed by an external identity provider. " +
+                "Please use your organisation's directory service to change your password.");
+
         IdentityResult res;
 
         if (currentPassword == null)
@@ -455,6 +484,10 @@ public class UsersManager : IUsersManager
 
         if (user == null)
             throw new BadRequestException("User does not exist");
+
+        if (Caps.ManagesProfileExternally)
+            throw new InvalidOperationException(
+                "Profile data (email) is synchronised from the identity provider and cannot be modified locally.");
 
         if (!string.IsNullOrWhiteSpace(email))
             user.Email = email;
@@ -658,6 +691,20 @@ public class UsersManager : IUsersManager
 
         if (user == null)
             throw new BadRequestException("User does not exist");
+
+        // For external providers, physically deleting a user is futile (the user would be re-created
+        // on the next login if still valid in the directory). Deactivate instead.
+        if (!Caps.SupportsLocalUserManagement)
+        {
+            _logger.LogWarning(
+                "User {UserName} is managed by an external identity provider. " +
+                "Deactivating instead of deleting", userName);
+
+            if (!await _userManager.IsInRoleAsync(user, ApplicationDbContext.DeactivatedRoleName))
+                await _userManager.AddToRoleAsync(user, ApplicationDbContext.DeactivatedRoleName);
+
+            return new DeleteUserResultDto { UserName = userName, DatasetResults = [] };
+        }
 
         // Validate successor if specified
         User successorUser = null;
@@ -1008,6 +1055,11 @@ public class UsersManager : IUsersManager
             if (!roles.Contains(ApplicationDbContext.AdminRoleName, StringComparer.OrdinalIgnoreCase))
                 throw new ArgumentException("Cannot remove admin role from admin user");
         }
+
+        if (Caps.ManagesRolesExternally)
+            throw new InvalidOperationException(
+                "Role assignments are managed by the identity provider (group membership) " +
+                "and cannot be modified locally.");
 
         var currentRoles = await _userManager.GetRolesAsync(user);
 

--- a/Registry.Web/Services/Managers/UsersManager.cs
+++ b/Registry.Web/Services/Managers/UsersManager.cs
@@ -98,6 +98,15 @@ public class UsersManager : IUsersManager
             user = await CreateUserInternal(new User { UserName = userName }, localPassword);
         }
 
+        // Deny access to deactivated accounts. External providers (LDAP/Remote) authorize the bind
+        // even after a user is deactivated locally, so this guard - placed before SyncRoles, which
+        // would otherwise strip the Deactivated role - is what actually enforces the deactivation.
+        if (await _userManager.IsInRoleAsync(user, ApplicationDbContext.DeactivatedRoleName))
+        {
+            _logger.LogWarning("Authentication denied: user {UserName} is deactivated", userName);
+            return null;
+        }
+
         if (!user.Metadata.IsSameAs(res.Metadata))
         {
             user.Metadata = res.Metadata;
@@ -126,6 +135,14 @@ public class UsersManager : IUsersManager
         // Create user if not exists because login manager has greenlighed us
         var user = await _userManager.FindByNameAsync(res.UserName) ??
                    await CreateUserInternal(new User { UserName = res.UserName }, CommonUtils.RandomString(16));
+
+        // Deny access to deactivated accounts (see Authenticate(userName, password) for rationale):
+        // the check runs before SyncRoles so the Deactivated role cannot be stripped by a re-login.
+        if (await _userManager.IsInRoleAsync(user, ApplicationDbContext.DeactivatedRoleName))
+        {
+            _logger.LogWarning("Authentication denied: user {UserName} is deactivated", res.UserName);
+            return null;
+        }
 
         if (!user.Metadata.IsSameAs(res.Metadata))
         {
@@ -696,6 +713,14 @@ public class UsersManager : IUsersManager
         // on the next login if still valid in the directory). Deactivate instead.
         if (!Caps.SupportsLocalUserManagement)
         {
+            // Deactivation only flags the account: no data transfer or resource cleanup is performed.
+            // Fail fast if a successor was requested so the caller is not misled into believing a
+            // transfer occurred.
+            if (!string.IsNullOrWhiteSpace(successor))
+                throw new BadRequestException(
+                    "Transferring data to a successor is not supported when an external identity " +
+                    "provider is active: the account is deactivated, not deleted.");
+
             _logger.LogWarning(
                 "User {UserName} is managed by an external identity provider. " +
                 "Deactivating instead of deleting", userName);

--- a/Registry.Web/Services/Managers/UsersManager.cs
+++ b/Registry.Web/Services/Managers/UsersManager.cs
@@ -134,7 +134,7 @@ public class UsersManager : IUsersManager
 
         // Create user if not exists because login manager has greenlighed us
         var user = await _userManager.FindByNameAsync(res.UserName) ??
-                   await CreateUserInternal(new User { UserName = res.UserName }, CommonUtils.RandomString(16));
+                   await CreateUserInternal(new User { UserName = res.UserName }, GenerateExternalUserPassword());
 
         // Deny access to deactivated accounts (see Authenticate(userName, password) for rationale):
         // the check runs before SyncRoles so the Deactivated role cannot be stripped by a re-login.

--- a/Registry.Web/Services/Managers/WmsManager.cs
+++ b/Registry.Web/Services/Managers/WmsManager.cs
@@ -196,7 +196,7 @@ public class WmsManager : OgcManagerBase, IWmsManager
             // per-layer try/catch; we never want a 500 here, so synthesize a fully transparent (or
             // background-colored) image of the requested size/format as a last-resort fallback.
             _logger.LogError(ex, "WMS GetMap safety-net fallback triggered for layers=[{L}] bbox=[{B}] crs={Crs} {W}x{H} fmt={F}",
-                string.Join(',', layers ?? Array.Empty<string>()), string.Join(',', bbox), crs, width, height, format);
+                string.Join(',', layers ?? []), string.Join(',', bbox), crs, width, height, format);
             return BuildFallbackImage(width, height, format, transparent, bgColor);
         }
     }

--- a/Registry.Web/Services/Managers/WmtsManager.cs
+++ b/Registry.Web/Services/Managers/WmtsManager.cs
@@ -239,7 +239,7 @@ public class WmtsManager : OgcManagerBase, IWmtsManager
                 // intersect the dataset coverage.
                 _logger.LogDebug("WMTS vector tile missing for {Layer} z={Z} x={X} y={Y}; returning empty MVT",
                     layerName, z, x, y);
-                return Array.Empty<byte>();
+                return [];
             }
             return await File.ReadAllBytesAsync(path);
         }
@@ -269,7 +269,7 @@ public class WmtsManager : OgcManagerBase, IWmtsManager
     {
         return (format ?? "").ToLowerInvariant() switch
         {
-            "application/vnd.mapbox-vector-tile" => Array.Empty<byte>(),
+            "application/vnd.mapbox-vector-tile" => [],
             "image/jpeg" => WhiteJpeg,
             _ => TransparentPng256,
         };

--- a/Registry.Web/Services/Ports/AuthProviderCapabilities.cs
+++ b/Registry.Web/Services/Ports/AuthProviderCapabilities.cs
@@ -1,0 +1,43 @@
+namespace Registry.Web.Services.Ports;
+
+/// <summary>
+/// Describes what an authentication provider allows to manage locally.
+/// Consumers (UsersManager, SystemController, bootstrap, health check) adapt their
+/// behaviour to these flags without knowing the concrete provider.
+/// </summary>
+public sealed record AuthProviderCapabilities
+{
+    /// <summary>Users can be created and deleted locally (admin UI, API).</summary>
+    public bool SupportsLocalUserManagement { get; init; }
+
+    /// <summary>Passwords can be changed through Registry.</summary>
+    public bool SupportsPasswordChange { get; init; }
+
+    /// <summary>Roles are determined by the provider; local editing must be inhibited.</summary>
+    public bool ManagesRolesExternally { get; init; }
+
+    /// <summary>Email and display name are synchronised from the provider; local editing must be inhibited.</summary>
+    public bool ManagesProfileExternally { get; init; }
+
+    /// <summary>
+    /// Capabilities for the local provider (full local control - historical behaviour).
+    /// </summary>
+    public static AuthProviderCapabilities Local { get; } = new()
+    {
+        SupportsLocalUserManagement = true,
+        SupportsPasswordChange = true,
+        ManagesRolesExternally = false,
+        ManagesProfileExternally = false
+    };
+
+    /// <summary>
+    /// Capabilities for external providers (Remote/LDAP): identity is managed outside Registry.
+    /// </summary>
+    public static AuthProviderCapabilities External { get; } = new()
+    {
+        SupportsLocalUserManagement = false,
+        SupportsPasswordChange = false,
+        ManagesRolesExternally = true,
+        ManagesProfileExternally = true
+    };
+}

--- a/Registry.Web/Services/Ports/ILoginManager.cs
+++ b/Registry.Web/Services/Ports/ILoginManager.cs
@@ -8,6 +8,14 @@ namespace Registry.Web.Services.Ports;
 
 public interface ILoginManager
 {
-    public Task<LoginResultDto> CheckAccess(string userName, string password);
-    public Task<LoginResultDto> CheckAccess(string token);
+    Task<LoginResultDto> CheckAccess(string userName, string password);
+    Task<LoginResultDto> CheckAccess(string token);
+
+    /// <summary>
+    /// Describes what this provider allows to manage locally.
+    /// Defaults to <see cref="AuthProviderCapabilities.External"/> so that any provider
+    /// that forgets to override it "fails closed" (disables local management rather than exposing it).
+    /// <see cref="LocalLoginManager"/> overrides this to <see cref="AuthProviderCapabilities.Local"/>.
+    /// </summary>
+    AuthProviderCapabilities Capabilities => AuthProviderCapabilities.External;
 }

--- a/Registry.Web/Services/Ports/ILoginManager.cs
+++ b/Registry.Web/Services/Ports/ILoginManager.cs
@@ -13,9 +13,10 @@ public interface ILoginManager
 
     /// <summary>
     /// Describes what this provider allows to manage locally.
-    /// Defaults to <see cref="AuthProviderCapabilities.External"/> so that any provider
-    /// that forgets to override it "fails closed" (disables local management rather than exposing it).
-    /// <see cref="LocalLoginManager"/> overrides this to <see cref="AuthProviderCapabilities.Local"/>.
+    /// Every implementation must declare this explicitly: <see cref="LocalLoginManager"/> returns
+    /// <see cref="AuthProviderCapabilities.Local"/>, while external providers (LDAP/Remote) return
+    /// <see cref="AuthProviderCapabilities.External"/>. No default is provided so that callers and
+    /// test doubles are forced to choose an explicit capability set.
     /// </summary>
-    AuthProviderCapabilities Capabilities => AuthProviderCapabilities.External;
+    AuthProviderCapabilities Capabilities { get; }
 }

--- a/Registry.Web/Startup.cs
+++ b/Registry.Web/Startup.cs
@@ -125,7 +125,16 @@ public class Startup
         services.AddDbContextWithProvider<ApplicationDbContext>(Configuration, appSettings.AuthProvider,
             MagicStrings.IdentityConnectionName, "Identity");
 
-        if (!string.IsNullOrWhiteSpace(appSettings.ExternalAuthUrl))
+        if (appSettings.LdapSettings?.Enabled == true)
+        {
+            services.AddIdentityCore<User>()
+                .AddRoles<IdentityRole>()
+                .AddEntityFrameworkStores<ApplicationDbContext>()
+                .AddDefaultTokenProviders();
+
+            services.AddScoped<ILoginManager, LdapLoginManager>();
+        }
+        else if (!string.IsNullOrWhiteSpace(appSettings.ExternalAuthUrl))
         {
             services.AddIdentityCore<User>()
                 .AddRoles<IdentityRole>()
@@ -228,7 +237,7 @@ public class Startup
             });
         }
 
-        services.AddHealthChecks()
+        var hcBuilder = services.AddHealthChecks()
             .AddCheck<CacheHealthCheck>("Cache health check", null, ["service"])
             .AddCheck<DdbHealthCheck>("DroneDB health check", null, ["service"])
             .AddCheck<UserManagerHealthCheck>("User manager health check", null, ["database"])
@@ -247,6 +256,9 @@ public class Startup
                 ["processing"])
             .AddCheck<HangFireHealthCheck>("Hangfire processing health check", null, ["processing"])
             .AddCheck<ThumbnailGeneratorHealthCheck>("Thumbnail generator health check", null, ["service"]);
+
+        if (appSettings.LdapSettings?.Enabled == true)
+            hcBuilder.AddCheck<LdapHealthCheck>("LDAP health check", null, ["service"]);
 
 
         /*


### PR DESCRIPTION
# Add LDAP / Active Directory authentication

## Summary
Adds LDAP/AD as an authentication provider for Registry and introduces an **auth-provider capability model** that lets the backend automatically adapt its user-management behavior when an external identity provider (LDAP, or the pre-existing Remote provider) is active.

## What's new
- **LDAP/AD login** (`LdapLoginManager`, via `System.DirectoryServices.Protocols`):
  - Service-account search bind (`BindDn` + `SearchFilter`) and direct bind (`UserDnFormat`).
  - LDAPS with optional certificate validation.
  - Admin role mapping from LDAP group membership (`AdminGroupDns` matched against `memberOf`).
  - RFC 4515 filter escaping of usernames.
- **`AuthProviderCapabilities`** (Local vs External) consumed by `UsersManager`, `SystemController`, bootstrap and health checks.
- **`LdapSettings`** configuration + validation (mutually exclusive with `ExternalAuthUrl`).
- **`LdapHealthCheck`** for LDAP connectivity/bind.

## Behavior changes (also affect the existing Remote/External provider)
> [!IMPORTANT]
> These apply whenever **any** external provider is active (LDAP **or** the pre-existing Remote / `ExternalAuthUrl` mode), not only LDAP:
- The **default local admin is not created** at startup; admin rights come from the provider's group mapping.
- **Local user management is disabled** (create user, change password, edit profile/roles) - identity is owned by the provider.
- The **local user-manager health check is skipped** (a provider-specific check runs instead).
- **Deleting** an externally-managed user **deactivates** it (adds the `Deactivated` role) instead of removing it, because it would be recreated on the next login. Passing a successor (data transfer) **fails fast** since transfer is not supported in this mode.
- **Authentication denies** users holding the `Deactivated` role **before** role sync, so deactivation cannot be bypassed by simply logging in again.

## Configuration
```jsonc
"LdapSettings": {
  "Enabled": true,
  "Server": "dc.example.com",
  "Port": 636,
  "UseSsl": true,
  "BaseDn": "dc=example,dc=com",
  "BindDn": "cn=svc,ou=svcaccts,dc=example,dc=com",
  "BindPassword": "***",
  "SearchFilter": "(sAMAccountName={0})",
  "AdminGroupDns": [ "cn=registry-admins,ou=groups,dc=example,dc=com" ]
}
```
LDAP and `ExternalAuthUrl` are mutually exclusive (enforced at startup).

## Runtime / Docker
`System.DirectoryServices.Protocols` P/Invokes OpenLDAP on Linux. The runtime image now installs `libldap2`, `libldap-common` and `libsasl2-2` (Ubuntu Noble). Verified that these provide `libldap.so.2` and all of its dependencies, so **no symlink workaround is needed** for the full `ubuntu:noble` base image.

## Testing
- Existing unit tests updated for the capability model.
- New **`[Explicit]`** end-to-end integration test (`LdapLoginManagerIntegrationTest`) that exercises `LdapLoginManager` and `LdapHealthCheck` against a real **glauth** LDAP server started via **Testcontainers** (Docker required). Covers valid/admin/invalid logins, empty credentials, LDAP filter-injection, the direct-bind (`UserDnFormat`) path, token auth, and the health check.

## Upgrade impact
Operators upgrading an instance that **already** uses Remote / `ExternalAuthUrl` will see local admin creation skipped and local user management disabled. Make sure the provider's admin group mapping is configured before upgrading.
